### PR TITLE
Add an option to choose default image picker method

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidx-activityCompose = "1.9.3"
 kotlinxDatetime = "0.6.1"
 logging = "1.4.2"
 materialKolor = "1.4.0-rc03"
-multiplatformSettings = "1.1.1"
+multiplatformSettings = "1.2.0"
 nativeDriver = "2.0.1"
 runtime = "2.0.2"
 statelyCommon = "2.0.5"
@@ -59,6 +59,7 @@ multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", vers
 multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatformSettings" }
 multiplatform-settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "multiplatformSettings" }
 multiplatform-settings-no-arg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatformSettings" }
+multiplatform-settings-make-observable = { module = "com.russhwolf:multiplatform-settings-make-observable", version.ref = "multiplatformSettings" }
 native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "nativeDriver" }
 runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "runtime" }
 stately-common = { module = "co.touchlab:stately-common", version.ref = "statelyCommon" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -92,6 +92,7 @@ kotlin {
             implementation(libs.multiplatform.settings.no.arg)
             implementation(libs.multiplatform.settings.serialization)
             implementation(libs.multiplatform.settings.coroutines)
+            implementation(libs.multiplatform.settings.make.observable)
             api(libs.image.loader)
             implementation(libs.coil.compose)
             implementation(libs.zoomimage.compose.coil3)

--- a/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/Platform.android.kt
@@ -1,7 +1,7 @@
 package io.github.yahiaangelo.filmsimulator
 
 class AndroidPlatform : Platform {
-    override val name: String = "Android ${android.os.Build.VERSION.SDK_INT}"
+    override val name = PlatformName.ANDROID
 }
 
 actual fun getPlatform(): Platform = AndroidPlatform()

--- a/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FFMPEGHandler.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FFMPEGHandler.android.kt
@@ -1,18 +1,29 @@
 package util
 
 import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.ReturnCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-actual suspend fun apply3dLut(inputFile: String, lutFile: String, outputFile: String, onComplete: () -> Unit) {
+actual suspend fun apply3dLut(inputFile: String, lutFile: String, outputFile: String, onComplete: () -> Unit, onError: (String) -> Unit) {
     val inputFileDir = "$systemTemporaryPath/$inputFile"
     val outputFileDir = "$systemTemporaryPath/$outputFile"
     val lutFileDir = "$systemTemporaryPath/$lutFile"
 
     deleteFile(outputFileDir)
     withContext(Dispatchers.IO) {
-        FFmpegKit.executeAsync("-i $inputFileDir -vf lut3d=$lutFileDir -q:v 1 $outputFileDir") {
-            onComplete()
+        FFmpegKit.executeAsync("-i $inputFileDir -vf lut3d=$lutFileDir -q:v 1 $outputFileDir") { session ->
+            if (ReturnCode.isSuccess(session.returnCode)) {
+                // SUCCESS
+                onComplete()
+
+            } else if (ReturnCode.isCancel(session.returnCode)) {
+                // CANCEL
+                onError("ffmpeg canceled by user")
+            } else {
+                // FAILURE
+                onError("ffmpeg failed, unsupported file format")
+            }
         }
     }
 }

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -13,6 +13,10 @@
     <string name="developer">Developer</string>
     <string name="source_code">Source Code</string>
     <string name="contact">Contact</string>
+    <string name="default_picker">Default Picker</string>
+    <string name="images">Images</string>
+    <string name="files">Files</string>
+    <string name="cancel">Cancel</string>
     <string name="about_text">Film Simulator is a tool to simulate the look of analog film using 3D LUTs. It is a free and open-source project. You can find the source code on GitHub.</string>
 
 </resources>

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/Platform.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/Platform.kt
@@ -1,7 +1,13 @@
 package io.github.yahiaangelo.filmsimulator
 
 interface Platform {
-    val name: String
+    val name: PlatformName
+}
+
+enum class PlatformName {
+    ANDROID,
+    IOS,
+    DESKTOP
 }
 
 expect fun getPlatform(): Platform

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/FilmRepository.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/FilmRepository.kt
@@ -30,7 +30,7 @@ interface FilmRepository {
 
     suspend fun downloadLutCube(name: String)
 
-    suspend fun applyFilmLut(scope: CoroutineScope, filmLut: FilmLut, image: String, onComplete: (String) -> Unit)
+    suspend fun applyFilmLut(scope: CoroutineScope, filmLut: FilmLut, image: String, onComplete: (String) -> Unit, onError: (String) -> Unit)
 
     // Methods for handling favorite LUTs
     fun getFavoriteFilmsStream(): Flow<List<FavoriteLut>>

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/local/SettingsStorage.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/local/SettingsStorage.kt
@@ -1,15 +1,19 @@
 package io.github.yahiaangelo.filmsimulator.data.source.local
 
+import io.github.yahiaangelo.filmsimulator.screens.settings.DefaultPickerType
+
 
 interface SettingsStorage {
 
     var exportQuality: Int
+    var defaultPicker: DefaultPickerType
+    fun defaultPickerListener(callback: (DefaultPickerType) -> Unit)
 
     fun cleanStorage()
 }
 
 enum class StorageKeys {
-    EXPORT_QUALITY;
-
+    EXPORT_QUALITY,
+    DEFAULT_PICKER;
     val key get() = this.name
 }

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -78,10 +78,11 @@ import io.github.vinceglb.filekit.core.PickerType
 import io.github.yahiaangelo.filmsimulator.FavoriteLut
 import io.github.yahiaangelo.filmsimulator.FilmLut
 import io.github.yahiaangelo.filmsimulator.data.source.network.GITHUB_BASE_URL
+import io.github.yahiaangelo.filmsimulator.screens.settings.DefaultPickerType
 import io.github.yahiaangelo.filmsimulator.screens.settings.SettingsScreen
+import io.github.yahiaangelo.filmsimulator.util.supportedImageExtensions
 import io.github.yahiaangelo.filmsimulator.view.AppScaffold
 import io.github.yahiaangelo.filmsimulator.view.ProgressDialog
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import okio.FileSystem
 import org.jetbrains.compose.resources.painterResource
@@ -104,7 +105,13 @@ data class HomeScreen(
         val vm = getScreenModel<HomeScreenModel>()
         val uiState by vm.uiState.collectAsState()
 
-        val singleImagePicker = rememberFilePickerLauncher(mode = PickerMode.Single, type = PickerType.Image, onResult = vm::onImagePickerResult)
+        val singleImagePicker = rememberFilePickerLauncher(
+            type = when(uiState.defaultPickerType) {
+                DefaultPickerType.IMAGES -> PickerType.Image
+                DefaultPickerType.FILES -> PickerType.File(supportedImageExtensions.toList())
+            }, mode = PickerMode.Single, onResult = vm::onImagePickerResult
+        )
+
 
         val homeScreenState = HomeUiState(
             image = uiState.image,

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreenModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreenModel.kt
@@ -121,7 +121,7 @@ data class HomeScreenModel(val repository: FilmRepository, val settingsRepositor
 
     fun onImagePickerResult(file: PlatformFile?) {
         file?.let { platformFile ->
-            if (!supportedImageExtensions.contains(platformFile.extension)) {
+            if (!supportedImageExtensions.contains(platformFile.extension.lowercase())) {
                 updateUiState { it.copy(userMessage = "Unsupported image type.") }
                 return
             }

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
@@ -1,15 +1,22 @@
 package io.github.yahiaangelo.filmsimulator.screens.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ListItem
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -20,13 +27,16 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
@@ -35,11 +45,14 @@ import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import film_simulator.shared.generated.resources.Res
-import film_simulator.shared.generated.resources.about
 import film_simulator.shared.generated.resources.app_version
 import film_simulator.shared.generated.resources.contact
+import film_simulator.shared.generated.resources.default_picker
 import film_simulator.shared.generated.resources.developer
+import film_simulator.shared.generated.resources.files
 import film_simulator.shared.generated.resources.image_export_quality
+import film_simulator.shared.generated.resources.images
+import film_simulator.shared.generated.resources.cancel
 import film_simulator.shared.generated.resources.settings
 import film_simulator.shared.generated.resources.source_code
 import io.github.yahiaangelo.filmsimulator.util.AppContext
@@ -50,13 +63,13 @@ import sh.calvin.autolinktext.rememberAutoLinkText
 
 class SettingsScreen : Screen {
 
-    @OptIn(ExperimentalMaterial3Api::class)
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val scaffoldState = rememberScaffoldState()
         val snackbarHostState = remember { SnackbarHostState() }
-
+        val showDefaultPickerDialog = remember { mutableStateOf(false) }
         val vm = getScreenModel<SettingsScreenModel>()
         val uiState by vm.uiState.collectAsState()
 
@@ -105,6 +118,24 @@ class SettingsScreen : Screen {
                     onValueChange = vm::updateExportQualitySettings
                 )
                 Spacer(modifier = Modifier.padding(16.dp))
+                ListItem(
+                    modifier = Modifier.clickable {
+                        showDefaultPickerDialog.value = true
+                    },
+                    text = {
+                        Text(
+                            text = stringResource(Res.string.default_picker),
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                    },
+                    secondaryText = {
+                        Text(
+                            text = stringResource(uiState.defaultPicker.getString()),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    },
+                )
+                Spacer(modifier = Modifier.padding(16.dp))
                 Divider(color = MaterialTheme.colorScheme.secondaryContainer, thickness = 1.dp)
                 AboutSection()
             }
@@ -116,8 +147,13 @@ class SettingsScreen : Screen {
                 vm.snackbarMessageShown()
             }
         }
+
+        DefaultPickerDialog(showDefaultPickerDialog.value, onItemClick = vm::updateDefaultPickerSettings) {
+            showDefaultPickerDialog.value = false
+        }
     }
 
+    @OptIn(ExperimentalMaterialApi::class)
     @Composable
     private fun SettingsSlider(
         name: String,
@@ -127,25 +163,27 @@ class SettingsScreen : Screen {
         onValueChange: (Float) -> Unit
     ) {
 
-        Column {
-            Text(
-                style = MaterialTheme.typography.labelLarge,
-                text = name
-            )
-            Slider(
-                value = value,
-                onValueChange = {
-                    onValueChange(it)
-                },
-                colors = SliderDefaults.colors(
-                    thumbColor = MaterialTheme.colorScheme.secondary,
-                    activeTrackColor = MaterialTheme.colorScheme.secondary,
-                    inactiveTrackColor = MaterialTheme.colorScheme.secondaryContainer,
-                ),
-                steps = steps,
-                valueRange = range
-            )
-            Text(text = value.toInt().toString())
+        ListItem {
+            Column {
+                Text(
+                    style = MaterialTheme.typography.labelLarge,
+                    text = name
+                )
+                Slider(
+                    value = value,
+                    onValueChange = {
+                        onValueChange(it)
+                    },
+                    colors = SliderDefaults.colors(
+                        thumbColor = MaterialTheme.colorScheme.secondary,
+                        activeTrackColor = MaterialTheme.colorScheme.secondary,
+                        inactiveTrackColor = MaterialTheme.colorScheme.secondaryContainer,
+                    ),
+                    steps = steps,
+                    valueRange = range
+                )
+                Text(text = value.toInt().toString())
+            }
         }
 
     }
@@ -155,38 +193,134 @@ class SettingsScreen : Screen {
     fun AboutSection() {
         Column(modifier = Modifier.padding(vertical = 16.dp)) {
             ListItem(
-                text = { Text(text = stringResource(Res.string.app_version)) },
-                secondaryText = { Text(text = Platform(AppContext).getAppVersion()) }
+                text = {
+                    Text(
+                        text = stringResource(Res.string.app_version),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                },
+                secondaryText = {
+                    Text(
+                        text = Platform(AppContext).getAppVersion(),
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
             )
 
             ListItem(
-                text = { Text(text = stringResource(Res.string.developer)) },
-                secondaryText = { Text(text = "YahiaAngelo") }
+                text = {
+                    Text(
+                        text = stringResource(Res.string.developer),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                },
+                secondaryText = {
+                    Text(
+                        text = "YahiaAngelo",
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
             )
 
             ListItem(
-                text = { Text(text = stringResource(Res.string.source_code)) },
+                text = {
+                    Text(
+                        text = stringResource(Res.string.source_code),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                },
                 secondaryText = {
                     Text(
                         AnnotatedString.rememberAutoLinkText(
                             "https://github.com/YahiaAngelo".trimMargin()
                         ),
+                        style = MaterialTheme.typography.labelMedium,
                     )
                 }
             )
 
             ListItem(
-                text = { Text(text = stringResource(Res.string.contact)) },
+                text = {
+                    Text(
+                        text = stringResource(Res.string.contact),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                },
                 secondaryText = {
                     Text(
                         AnnotatedString.rememberAutoLinkText(
                             "https://x.com/YahiaDev".trimMargin()
                         ),
+                        style = MaterialTheme.typography.labelMedium,
                     )
                 }
             )
 
 
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+    @Composable
+    fun DefaultPickerDialog(
+        show: Boolean,
+        onItemClick: (DefaultPickerType) -> Unit,
+        onDismiss: () -> Unit
+    ) {
+        if (show) {
+            BasicAlertDialog(
+                onDismissRequest = onDismiss
+            ) {
+                Surface(
+                    modifier = Modifier.wrapContentWidth().wrapContentHeight(),
+                    shape = MaterialTheme.shapes.large,
+                    tonalElevation = AlertDialogDefaults.TonalElevation
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = stringResource(Res.string.default_picker),
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        ListItem(
+                            text = {
+                                Text(
+                                    text = stringResource(Res.string.images),
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                onItemClick(DefaultPickerType.IMAGES)
+                                onDismiss()
+                            }
+                        )
+                        ListItem(
+                            text = {
+                                Text(
+                                    text = stringResource(Res.string.files),
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                onItemClick(DefaultPickerType.FILES)
+                                onDismiss()
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        TextButton(
+                            modifier = Modifier.align(Alignment.End),
+                            onClick = onDismiss
+
+                        ) {
+                            Text(
+                                text = stringResource(Res.string.cancel),
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreenModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreenModel.kt
@@ -2,6 +2,9 @@ package io.github.yahiaangelo.filmsimulator.screens.settings
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
+import film_simulator.shared.generated.resources.Res
+import film_simulator.shared.generated.resources.files
+import film_simulator.shared.generated.resources.images
 import io.github.yahiaangelo.filmsimulator.data.source.SettingsRepository
 import io.github.yahiaangelo.filmsimulator.util.WhileUiSubscribed
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -9,6 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
 import org.koin.dsl.module
 
 val settingsScreenModel = module {
@@ -17,18 +21,33 @@ val settingsScreenModel = module {
 
 data class SettingsUiState(
     val exportQuality: Int = 0,
+    val defaultPicker: DefaultPickerType = DefaultPickerType.IMAGES,
     val userMessage: String? = null,
 )
+
+enum class DefaultPickerType {
+    IMAGES,
+    FILES;
+
+    fun getString(): StringResource {
+        return when (this) {
+            IMAGES -> Res.string.images
+            FILES -> Res.string.files
+        }
+    }
+}
 class SettingsScreenModel(val repository: SettingsRepository): ScreenModel {
 
     private val _exportQuality: MutableStateFlow<Int> = MutableStateFlow(repository.getSettings().exportQuality)
+    private val _defaultPicker: MutableStateFlow<DefaultPickerType> = MutableStateFlow(repository.getSettings().defaultPicker)
     private val _userMessage: MutableStateFlow<String?> = MutableStateFlow(null)
 
     val uiState: StateFlow<SettingsUiState> = combine(
-        _exportQuality, _userMessage
-    ) { exportQuality, userMessage ->
+        _exportQuality, _defaultPicker, _userMessage
+    ) { exportQuality, defaultPicker, userMessage ->
         SettingsUiState(
             exportQuality = exportQuality,
+            defaultPicker = defaultPicker,
             userMessage = userMessage
         )
     }
@@ -48,6 +67,13 @@ class SettingsScreenModel(val repository: SettingsRepository): ScreenModel {
         screenModelScope.launch {
             repository.getSettings().exportQuality = quality.toInt()
             _exportQuality.emit(quality.toInt())
+        }
+    }
+
+    fun updateDefaultPickerSettings(defaultPicker: DefaultPickerType) {
+        screenModelScope.launch {
+            repository.getSettings().defaultPicker = defaultPicker
+            _defaultPicker.emit(defaultPicker)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FFMPEGHandler.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FFMPEGHandler.kt
@@ -3,4 +3,4 @@ package util
 /**
  * Main function to apply cube lut to an image using FFMPEG
  */
-expect suspend fun apply3dLut(inputFile: String, lutFile: String, outputFile: String, onComplete: () -> Unit)
+expect suspend fun apply3dLut(inputFile: String, lutFile: String, outputFile: String, onComplete: () -> Unit, onError: (String) -> Unit)

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/util/ImageUtils.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/util/ImageUtils.kt
@@ -6,6 +6,14 @@ import androidx.compose.ui.graphics.ImageBitmap
  * Main file for image processing
  */
 
+// List of supported image extensions
+val supportedImageExtensions = arrayOf(
+    "jpg", "jpeg", "png", "gif", "bmp", "webp",
+    "tiff", "tif", "heif", "heic", "ico",
+    "svg", "raw", "dng", "cr2", "nef", "orf",
+    "arw", "raf", "pef", "sr2", "rw2"
+)
+
 /**
  * Add film grain to an image
  */

--- a/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/Platform.ios.kt
@@ -3,7 +3,7 @@ package io.github.yahiaangelo.filmsimulator
 import platform.UIKit.UIDevice
 
 class IOSPlatform: Platform {
-    override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+    override val name = PlatformName.IOS
 }
 
 actual fun getPlatform(): Platform = IOSPlatform()

--- a/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FFMPEGHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FFMPEGHandler.ios.kt
@@ -1,21 +1,32 @@
 package util
 
 import cocoapods.ffmpeg_kit_ios_min.FFmpegKit
+import cocoapods.ffmpeg_kit_ios_min.ReturnCode
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalForeignApi::class)
-actual suspend fun apply3dLut(inputFile: String, lutFile: String, outputFile: String, onComplete: () -> Unit) {
+actual suspend fun apply3dLut(inputFile: String, lutFile: String, outputFile: String, onComplete: () -> Unit, onError: (String) -> Unit) {
     val inputFileDir = "$systemTemporaryPath/$inputFile"
     val outputFileDir = "$systemTemporaryPath/$outputFile"
     val lutFileDir = "$systemTemporaryPath/$lutFile"
 
     deleteFile(outputFileDir)
     withContext(Dispatchers.IO) {
-        FFmpegKit.executeAsync("-i $inputFileDir -vf lut3d=$lutFileDir -q:v 1 $outputFileDir") {
-            onComplete()
+        FFmpegKit.executeAsync("-i $inputFileDir -vf lut3d=$lutFileDir -q:v 1 $outputFileDir") { session ->
+            if (ReturnCode.isSuccess(session?.getReturnCode())) {
+                // SUCCESS
+                onComplete()
+
+            } else if (ReturnCode.isCancel(session?.getReturnCode())) {
+                // CANCEL
+                onError("ffmpeg canceled by user")
+            } else {
+                // FAILURE
+                onError("ffmpeg failed, unsupported file format")
+            }
         }
     }
 }


### PR DESCRIPTION
The file picker is not handling image intents correctly in Android, So some image intents refer to non-existing images somehow, will temporarily fix this by adding an option to select images as files, that fixes it and also adds the ability to select image files from the device, which many people requested.