### PR TITLE
Refactor screen model imports to use koinScreenModel and adjust export quality slider range

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -82,12 +82,11 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.core.screen.uniqueScreenKey
-import cafe.adriel.voyager.koin.getScreenModel
+import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
-import coil3.compose.SubcomposeAsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
@@ -152,7 +151,7 @@ data class HomeScreen(
         val navigator = LocalNavigator.currentOrThrow
         val snackbarHostState = remember { SnackbarHostState() }
 
-        val vm = getScreenModel<HomeScreenModel>()
+        val vm = koinScreenModel<HomeScreenModel>()
         val uiState by vm.uiState.collectAsState()
 
         val singleImagePicker = rememberFilePickerLauncher(

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.core.screen.uniqueScreenKey
-import cafe.adriel.voyager.koin.getScreenModel
+import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import film_simulator.shared.generated.resources.Res
@@ -88,7 +88,7 @@ class SettingsScreen : Screen {
         val snackbarHostState = remember { SnackbarHostState() }
         val showDefaultPickerDialog = remember { mutableStateOf(false) }
         val showExportFormatDialog = remember { mutableStateOf(false) }
-        val vm = getScreenModel<SettingsScreenModel>()
+        val vm = koinScreenModel<SettingsScreenModel>()
         val uiState by vm.uiState.collectAsState()
 
         val lutDownloadManager = remember { getKoin().get<LutDownloadManager>() }
@@ -135,8 +135,8 @@ class SettingsScreen : Screen {
                 SettingsSlider(
                     name = stringResource(Res.string.image_export_quality),
                     value = uiState.exportQuality.toFloat(),
-                    steps = 4,
-                    range = 25f..100f,
+                    steps = 8,
+                    range = 10f..100f,
                     onValueChange = vm::updateExportQualitySettings
                 )
                 Spacer(modifier = Modifier.padding(16.dp))


### PR DESCRIPTION
This pull request updates the way screen models are retrieved in both the `HomeScreen` and `SettingsScreen` components, switching from the deprecated `getScreenModel` to the recommended `koinScreenModel` API. Additionally, it adjusts the export quality slider in the settings to allow for a wider and more granular range. These changes improve code maintainability and enhance user control over export quality.

**Screen Model Retrieval Modernization:**

* Replaced all usages of `getScreenModel` with `koinScreenModel` in both `HomeScreen.kt` and `SettingsScreen.kt` to align with the latest Voyager Koin integration best practices. [[1]](diffhunk://#diff-bf6669d0d51b132b199e9dfafb2b77f9ad0471d1b4ee74b29a94df077facba3fL85-L90) [[2]](diffhunk://#diff-bf6669d0d51b132b199e9dfafb2b77f9ad0471d1b4ee74b29a94df077facba3fL155-R154) [[3]](diffhunk://#diff-e9a540fe30c0a37f1afeca1a8227d128617046c97b39c78825b4165016f44077L47-R47) [[4]](diffhunk://#diff-e9a540fe30c0a37f1afeca1a8227d128617046c97b39c78825b4165016f44077L91-R91)

**Settings UI Improvements:**

* Increased the `SettingsSlider` for image export quality from 4 to 8 steps and expanded its range from `25f..100f` to `10f..100f` in `SettingsScreen.kt`, allowing users finer and broader control over export quality.

closes #54 