### PR TITLE
Update HomeScreen to use ZoomImage and BitmapPainter for improved image handling

### DIFF
--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -85,13 +85,15 @@ import cafe.adriel.voyager.core.screen.uniqueScreenKey
 import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import androidx.compose.ui.graphics.decodeToImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import com.github.panpf.zoomimage.CoilZoomAsyncImage
-import com.github.panpf.zoomimage.rememberCoilZoomState
+import com.github.panpf.zoomimage.ZoomImage
+import com.github.panpf.zoomimage.compose.rememberZoomState
 
 import film_simulator.shared.generated.resources.Res
 import film_simulator.shared.generated.resources.film
@@ -255,7 +257,7 @@ data class HomeScreen(
         state: HomeUiState,
         modifier: Modifier = Modifier
     ) {
-        val zoomState = rememberCoilZoomState()
+        val zoomState = rememberZoomState()
         Column(modifier = modifier.padding(horizontal = 18.dp)) {
             Spacer(modifier = Modifier.size(23.dp))
             Box(modifier = Modifier.fillMaxWidth()) {
@@ -271,19 +273,15 @@ data class HomeScreen(
                 ) {
                     Box(modifier = Modifier.fillMaxSize()) {
                         state.previewImage?.let { bytes ->
-                            val cacheKey = "preview-${state.previewToken}"
-                            CoilZoomAsyncImage(
+                            val painter = remember(bytes) {
+                                BitmapPainter(bytes.decodeToImageBitmap())
+                            }
+                            ZoomImage(
                                 modifier = Modifier.fillMaxSize(),
                                 zoomState = zoomState,
-                                model = ImageRequest.Builder(LocalPlatformContext.current)
-                                    .data(bytes)
-                                    .memoryCacheKey(cacheKey)
-                                    .diskCacheKey(cacheKey)
-                                    .memoryCachePolicy(CachePolicy.DISABLED)
-                                    .diskCachePolicy(CachePolicy.DISABLED)
-                                    .build(),
+                                painter = painter,
                                 contentDescription = null,
-                                scrollBar = null
+                                scrollBar = null,
                             )
                         } ?: IconButton(
                             modifier = Modifier.align(Alignment.Center).size(150.dp),

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -128,7 +128,9 @@ import io.github.yahiaangelo.filmsimulator.view.LutDownloadDialog
 import io.github.yahiaangelo.filmsimulator.view.LutDownloadProgressDialog
 import io.github.yahiaangelo.filmsimulator.view.ProgressDialog
 import io.github.yahiaangelo.filmsimulator.view.SettingsSlider
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import util.THUMBNAILS_DIR
@@ -273,16 +275,23 @@ data class HomeScreen(
                 ) {
                     Box(modifier = Modifier.fillMaxSize()) {
                         state.previewImage?.let { bytes ->
-                            val painter = remember(bytes) {
-                                BitmapPainter(bytes.decodeToImageBitmap())
+                            // Decode off the main thread; keep the previous painter visible
+                            // until the new one is ready so the toggle/preview swap stays smooth.
+                            var painter by remember { mutableStateOf<BitmapPainter?>(null) }
+                            LaunchedEffect(bytes) {
+                                painter = withContext(Dispatchers.Default) {
+                                    BitmapPainter(bytes.decodeToImageBitmap())
+                                }
                             }
-                            ZoomImage(
-                                modifier = Modifier.fillMaxSize(),
-                                zoomState = zoomState,
-                                painter = painter,
-                                contentDescription = null,
-                                scrollBar = null,
-                            )
+                            painter?.let { p ->
+                                ZoomImage(
+                                    modifier = Modifier.fillMaxSize(),
+                                    zoomState = zoomState,
+                                    painter = p,
+                                    contentDescription = null,
+                                    scrollBar = null,
+                                )
+                            }
                         } ?: IconButton(
                             modifier = Modifier.align(Alignment.Center).size(150.dp),
                             onClick = state.onImageChooseClick


### PR DESCRIPTION
This pull request refactors how zoomable images are displayed in the `HomeScreen` by replacing the use of the `CoilZoomAsyncImage` component with the more generic `ZoomImage` component. It also updates related imports and state management to align with the new approach. This change simplifies image handling and removes direct dependencies on Coil for zoomable images.

**Image display refactor:**

* Replaced `CoilZoomAsyncImage` with `ZoomImage`, now using a `BitmapPainter` created from raw image bytes instead of a Coil image request. This removes the need for custom cache keys and disables explicit caching policies.
* Updated the zoom state hook from `rememberCoilZoomState` to the more generic `rememberZoomState` to match the new image component.

**Imports cleanup and updates:**

* Removed unused Coil and ZoomImage imports and added necessary imports for `decodeToImageBitmap` and `BitmapPainter` to support the new image handling approach.

Closes #53 