### PR TITLE
Enhance image saving functionality by updating file paths and timestmps for better organization in the gallery

### DIFF
--- a/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.android.kt
@@ -70,10 +70,15 @@ actual suspend fun saveImageToGallery(
     }
     val (compressFormat, mimeType, fileExt) = resolveEncoding(targetExt)
 
+    val now = System.currentTimeMillis()
     val contentValues = ContentValues().apply {
-        put(MediaStore.MediaColumns.DISPLAY_NAME, "image_${System.currentTimeMillis()}.$fileExt")
+        put(MediaStore.MediaColumns.DISPLAY_NAME, "image_$now.$fileExt")
         put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
-        put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+        put(MediaStore.MediaColumns.RELATIVE_PATH, "${Environment.DIRECTORY_DCIM}/FilmSimulator")
+        // Override the gallery's sort-time so the export shows up at the top of
+        // the timeline. The EXIF DateTimeOriginal (true capture moment) is still
+        // preserved inside the file for archival purposes — see copyExif.
+        put(MediaStore.MediaColumns.DATE_TAKEN, now)
     }
 
     val resolver = context.contentResolver
@@ -138,8 +143,11 @@ private fun resolveEncoding(srcExt: String): Encoding = when (srcExt) {
 private fun copyExif(sourcePath: String, destPath: String) {
     val src = ExifInterface(sourcePath)
     val dst = ExifInterface(destPath)
+    // TAG_DATETIME / TAG_SUBSEC_TIME represent the file's last-modified time, not
+    // the moment the shutter fired — we intentionally let those default to "now"
+    // so the export reads as freshly modified, while DATETIME_ORIGINAL /
+    // DATETIME_DIGITIZED preserve the actual capture moment for archival.
     val tagsToCopy = arrayOf(
-        ExifInterface.TAG_DATETIME,
         ExifInterface.TAG_DATETIME_ORIGINAL,
         ExifInterface.TAG_DATETIME_DIGITIZED,
         ExifInterface.TAG_MAKE,
@@ -159,7 +167,6 @@ private fun copyExif(sourcePath: String, destPath: String) {
         ExifInterface.TAG_GPS_TIMESTAMP,
         ExifInterface.TAG_GPS_DATESTAMP,
         ExifInterface.TAG_GPS_PROCESSING_METHOD,
-        ExifInterface.TAG_SUBSEC_TIME,
         ExifInterface.TAG_SUBSEC_TIME_ORIGINAL,
         ExifInterface.TAG_SUBSEC_TIME_DIGITIZED,
     )

--- a/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
@@ -2,7 +2,6 @@ package util
 
 import io.github.yahiaangelo.filmsimulator.screens.settings.ExportFormat
 import io.github.yahiaangelo.filmsimulator.util.AppContext
-import io.github.yahiaangelo.filmsimulator.util.toUIImage
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.IntVar
@@ -24,6 +23,8 @@ import platform.CoreFoundation.CFRelease
 import platform.CoreFoundation.CFURLRef
 import platform.CoreFoundation.kCFNumberIntType
 import platform.Foundation.CFBridgingRetain
+import platform.Foundation.NSDate
+import platform.Foundation.NSMutableArray
 import platform.Foundation.NSURL
 import platform.Foundation.NSUUID
 import platform.Foundation.NSTemporaryDirectory
@@ -34,11 +35,17 @@ import platform.ImageIO.CGImageSourceCopyPropertiesAtIndex
 import platform.ImageIO.CGImageSourceCreateWithURL
 import platform.ImageIO.CGImageSourceGetType
 import platform.ImageIO.kCGImagePropertyOrientation
+import platform.Photos.PHAssetCollection
+import platform.Photos.PHAssetCollectionChangeRequest
+import platform.Photos.PHAssetCollectionSubtypeAlbumRegular
+import platform.Photos.PHAssetCollectionTypeAlbum
 import platform.Photos.PHAssetCreationRequest
 import platform.Photos.PHAssetResourceTypePhoto
+import platform.Photos.PHObjectPlaceholder
 import platform.Photos.PHPhotoLibrary
-import platform.UIKit.UIImageWriteToSavedPhotosAlbum
 import kotlin.coroutines.resume
+
+private const val ALBUM_TITLE = "Film Simulator"
 
 actual val systemTemporaryPath = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
 actual fun saveImageFile(fileName: String, image: ByteArray) {
@@ -87,8 +94,13 @@ actual suspend fun saveImageToGallery(
         // Fall through to plain JPEG path on failure.
     }
 
-    val uiImage = readImageFile(image).toUIImage()!!
-    UIImageWriteToSavedPhotosAlbum(uiImage, null, null, null)
+    // Plain path: import the already-encoded processed JPEG straight into the
+    // app album via PhotoKit. Going through PhotoKit (rather than the older
+    // UIImageWriteToSavedPhotosAlbum) is what lets us place the asset inside a
+    // named album rather than dumping it into the camera roll.
+    val processedPath = "${systemTemporaryPath / image}"
+    val processedUrl = NSURL.fileURLWithPath(processedPath)
+    saveAssetToAppAlbum(processedUrl)
 }
 
 /**
@@ -160,6 +172,10 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
         if (!ok) return@withContext false
 
         suspendCancellableCoroutine<Boolean> { continuation ->
+            // Look up the album outside performChanges — the fetch is a read and
+            // performChanges is the write transaction. Inside the block we either
+            // mutate the existing album or create a new one.
+            val existingAlbum = findAppAlbum()
             PHPhotoLibrary.sharedPhotoLibrary().performChanges({
                 val request = PHAssetCreationRequest.creationRequestForAsset()
                 request.addResourceWithType(
@@ -167,6 +183,12 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
                     tmpUrl,
                     null,
                 )
+                // EXIF DateTimeOriginal stays intact inside the file (archival
+                // metadata) — but the PHAsset's creationDate is what Photos.app
+                // uses for sorting, so we set it to "now" so exports surface at
+                // the top of Recents and the app album.
+                request.setCreationDate(NSDate())
+                addAssetToAppAlbum(request.placeholderForCreatedAsset(), existingAlbum)
             }, completionHandler = { success, _ ->
                 runCatching { FileSystem.SYSTEM.delete(tmpPath.toPath()) }
                 destinationTmpPath = null
@@ -179,6 +201,64 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
         if (mergedProps != null) CFRelease(mergedProps)
         destinationTmpPath?.let { runCatching { FileSystem.SYSTEM.delete(it.toPath()) } }
     }
+}
+
+/**
+ * Save a file at [fileUrl] as a new asset in the app's Photos album,
+ * creating the album if it doesn't exist yet.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private suspend fun saveAssetToAppAlbum(fileUrl: NSURL): Boolean =
+    suspendCancellableCoroutine { continuation ->
+        val existingAlbum = findAppAlbum()
+        PHPhotoLibrary.sharedPhotoLibrary().performChanges({
+            val request = PHAssetCreationRequest.creationRequestForAsset()
+            request.addResourceWithType(PHAssetResourceTypePhoto, fileUrl, null)
+            // Stamp the asset's sort-time as "now" so the export lands at the
+            // top of Recents; the embedded EXIF capture date is left untouched.
+            request.setCreationDate(NSDate())
+            addAssetToAppAlbum(request.placeholderForCreatedAsset(), existingAlbum)
+        }, completionHandler = { success, _ ->
+            continuation.resume(success)
+        })
+    }
+
+/**
+ * Inside a [PHPhotoLibrary.performChanges] block, add the just-created asset
+ * (represented by [placeholder]) to the app album. If [existingAlbum] is null
+ * a new album with [ALBUM_TITLE] is created in the same transaction.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun addAssetToAppAlbum(
+    placeholder: PHObjectPlaceholder?,
+    existingAlbum: PHAssetCollection?,
+) {
+    if (placeholder == null) return
+    val albumRequest = if (existingAlbum != null) {
+        PHAssetCollectionChangeRequest.changeRequestForAssetCollection(existingAlbum)
+    } else {
+        PHAssetCollectionChangeRequest.creationRequestForAssetCollectionWithTitle(ALBUM_TITLE)
+    }
+    // PHAssetCollectionChangeRequest.addAssets expects an NSFastEnumeration —
+    // NSMutableArray adopts it. We wrap the single placeholder so the call works
+    // for the common one-asset-at-a-time export flow.
+    val assets = NSMutableArray()
+    assets.addObject(placeholder)
+    albumRequest?.addAssets(assets)
+}
+
+private fun findAppAlbum(): PHAssetCollection? {
+    val result = PHAssetCollection.fetchAssetCollectionsWithType(
+        PHAssetCollectionTypeAlbum,
+        PHAssetCollectionSubtypeAlbumRegular,
+        null,
+    )
+    val count = result.count.toInt()
+    for (i in 0 until count) {
+        val collection = result.objectAtIndex(i.toULong()) as? PHAssetCollection
+        if (collection?.localizedTitle == ALBUM_TITLE) return collection
+    }
+    return null
 }
 
 private fun extensionForExtension(srcExt: String): String = when (srcExt) {


### PR DESCRIPTION
This pull request improves how exported images are saved to the gallery on both Android and iOS. The main focus is to ensure that exported images appear at the top of the gallery or album timeline by setting their sort-time to the current moment, while still preserving the original capture date in the EXIF metadata. Additionally, iOS exports are now placed in a dedicated app album instead of the general camera roll.

**Android gallery export improvements:**

* The exported image is now saved in the `DCIM/FilmSimulator` directory instead of the default Pictures directory, making it easier to find app exports. The gallery sort-time (`DATE_TAKEN`) is set to the current time so the export appears at the top of the timeline, but the original capture date is still preserved in the EXIF metadata.
* When copying EXIF data, tags representing the file's last-modified time (such as `TAG_DATETIME` and `TAG_SUBSEC_TIME`) are intentionally excluded to allow the file to appear as freshly modified in the gallery, while archival tags like `DATETIME_ORIGINAL` are preserved. [[1]](diffhunk://#diff-8dbea393e5453396832daea0e9ce49a73cb09dd7a0ba3e5a59887f4dc588ec8bR146-L142) [[2]](diffhunk://#diff-8dbea393e5453396832daea0e9ce49a73cb09dd7a0ba3e5a59887f4dc588ec8bL162)

**iOS gallery export improvements:**

* Instead of saving exports to the general camera roll, images are now added to a dedicated "Film Simulator" album using PhotoKit, making them easier to locate. [[1]](diffhunk://#diff-ae3360e545166e24b06c2900d1821a7ad1fd06128cb30ef9776949b07208a349R38-R49) [[2]](diffhunk://#diff-ae3360e545166e24b06c2900d1821a7ad1fd06128cb30ef9776949b07208a349L90-R103) [[3]](diffhunk://#diff-ae3360e545166e24b06c2900d1821a7ad1fd06128cb30ef9776949b07208a349R206-R263)
* When saving an image to the gallery, the `creationDate` of the asset is set to the current time so the export appears at the top of Recents and the app album, while the embedded EXIF capture date remains unchanged for archival purposes.
* Helper functions were added to find or create the app album and to ensure assets are correctly added to it.

These changes improve the user experience by making exported images more visible and organized, while maintaining accurate archival metadata.

Closes #52 