### PR TITLE
Development merge

### DIFF
--- a/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.android.kt
@@ -70,10 +70,15 @@ actual suspend fun saveImageToGallery(
     }
     val (compressFormat, mimeType, fileExt) = resolveEncoding(targetExt)
 
+    val now = System.currentTimeMillis()
     val contentValues = ContentValues().apply {
-        put(MediaStore.MediaColumns.DISPLAY_NAME, "image_${System.currentTimeMillis()}.$fileExt")
+        put(MediaStore.MediaColumns.DISPLAY_NAME, "image_$now.$fileExt")
         put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
-        put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+        put(MediaStore.MediaColumns.RELATIVE_PATH, "${Environment.DIRECTORY_DCIM}/FilmSimulator")
+        // Override the gallery's sort-time so the export shows up at the top of
+        // the timeline. The EXIF DateTimeOriginal (true capture moment) is still
+        // preserved inside the file for archival purposes — see copyExif.
+        put(MediaStore.MediaColumns.DATE_TAKEN, now)
     }
 
     val resolver = context.contentResolver
@@ -138,8 +143,11 @@ private fun resolveEncoding(srcExt: String): Encoding = when (srcExt) {
 private fun copyExif(sourcePath: String, destPath: String) {
     val src = ExifInterface(sourcePath)
     val dst = ExifInterface(destPath)
+    // TAG_DATETIME / TAG_SUBSEC_TIME represent the file's last-modified time, not
+    // the moment the shutter fired — we intentionally let those default to "now"
+    // so the export reads as freshly modified, while DATETIME_ORIGINAL /
+    // DATETIME_DIGITIZED preserve the actual capture moment for archival.
     val tagsToCopy = arrayOf(
-        ExifInterface.TAG_DATETIME,
         ExifInterface.TAG_DATETIME_ORIGINAL,
         ExifInterface.TAG_DATETIME_DIGITIZED,
         ExifInterface.TAG_MAKE,
@@ -159,7 +167,6 @@ private fun copyExif(sourcePath: String, destPath: String) {
         ExifInterface.TAG_GPS_TIMESTAMP,
         ExifInterface.TAG_GPS_DATESTAMP,
         ExifInterface.TAG_GPS_PROCESSING_METHOD,
-        ExifInterface.TAG_SUBSEC_TIME,
         ExifInterface.TAG_SUBSEC_TIME_ORIGINAL,
         ExifInterface.TAG_SUBSEC_TIME_DIGITIZED,
     )

--- a/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.android.kt
@@ -3,16 +3,20 @@ package util
 import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
+import android.media.ExifInterface
 import android.os.Environment
 import android.provider.MediaStore
 import androidx.compose.ui.graphics.asAndroidBitmap
 import io.github.yahiaangelo.filmsimulator.data.source.local.SettingsStorageImpl
+import io.github.yahiaangelo.filmsimulator.screens.settings.ExportFormat
 import io.github.yahiaangelo.filmsimulator.util.AppContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import org.jetbrains.compose.resources.decodeToImageBitmap
+import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 
 actual val systemTemporaryPath = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
@@ -48,25 +52,123 @@ suspend fun deleteFile(filePath: String) {
     }
 }
 
-actual suspend fun saveImageToGallery(image: String, appContext: AppContext) {
+actual suspend fun saveImageToGallery(
+    image: String,
+    appContext: AppContext,
+    format: ExportFormat,
+    originalImage: String?,
+) {
     val context: Context = appContext.get()!!
     val settings = SettingsStorageImpl()
 
+    // Decide actual encoding + MIME based on user preference and source format.
+    // If the user picked ORIGINAL but we don't have the source file, fall back to JPEG.
+    val targetExt = if (format == ExportFormat.ORIGINAL && originalImage != null) {
+        originalImage.substringAfterLast('.', "jpeg").lowercase()
+    } else {
+        "jpeg"
+    }
+    val (compressFormat, mimeType, fileExt) = resolveEncoding(targetExt)
+
     val contentValues = ContentValues().apply {
-        put(MediaStore.MediaColumns.DISPLAY_NAME, "image_${System.currentTimeMillis()}")
-        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+        put(MediaStore.MediaColumns.DISPLAY_NAME, "image_${System.currentTimeMillis()}.$fileExt")
+        put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
         put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
     }
 
     val resolver = context.contentResolver
     val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
-    uri?.let {
-        resolver.openOutputStream(it).use { outputStream ->
+        ?: throw IOException("Failed to create new MediaStore record.")
+
+    val bitmap = readImageFile(image).decodeToImageBitmap().asAndroidBitmap()
+
+    if (format == ExportFormat.ORIGINAL && originalImage != null && mimeType == "image/jpeg") {
+        // JPEG output with EXIF: encode to a temp file first so we can rewrite EXIF on it,
+        // then stream the result into MediaStore.
+        val tmp = File.createTempFile("export_", ".jpg", context.cacheDir)
+        try {
+            FileOutputStream(tmp).use { out ->
+                bitmap.compress(compressFormat, settings.exportQuality, out)
+            }
+            val sourcePath = "${systemTemporaryPath / originalImage}"
+            runCatching { copyExif(sourcePath, tmp.absolutePath) }
+            resolver.openOutputStream(uri).use { outputStream ->
+                outputStream?.write(tmp.readBytes())
+            }
+        } finally {
+            tmp.delete()
+        }
+    } else {
+        // Either plain JPEG export (original behavior) or a non-JPEG re-encode
+        // (PNG / WEBP / HEIC). For non-JPEG, EXIF embedding is not portable enough
+        // across Android versions to be worth the complexity; we re-encode in the
+        // chosen format so the user at least gets the source file's pixel format.
+        resolver.openOutputStream(uri).use { outputStream ->
             if (outputStream != null) {
-                readImageFile(image).decodeToImageBitmap().asAndroidBitmap().compress(Bitmap.CompressFormat.JPEG, settings.exportQuality, outputStream)
+                bitmap.compress(compressFormat, settings.exportQuality, outputStream)
             }
         }
-    } ?: throw IOException("Failed to create new MediaStore record.")
+    }
+}
+
+private data class Encoding(
+    val format: Bitmap.CompressFormat,
+    val mime: String,
+    val ext: String,
+)
+
+private fun resolveEncoding(srcExt: String): Encoding = when (srcExt) {
+    "png" -> Encoding(Bitmap.CompressFormat.PNG, "image/png", "png")
+    "webp" -> Encoding(
+        @Suppress("DEPRECATION") Bitmap.CompressFormat.WEBP,
+        "image/webp",
+        "webp",
+    )
+    // Android's Bitmap API does not expose HEIC/HEIF encoding (HeifWriter is the
+    // dedicated API and is significantly more complex). For these sources we
+    // fall back to JPEG, which still preserves EXIF metadata via the JPEG path.
+    else -> Encoding(Bitmap.CompressFormat.JPEG, "image/jpeg", "jpg")
+}
+
+/**
+ * Copy EXIF tags from a source JPEG/HEIC/whatever into a destination JPEG file.
+ * Resets the orientation tag because the destination's pixels have orientation
+ * already baked in by the processing pipeline.
+ */
+private fun copyExif(sourcePath: String, destPath: String) {
+    val src = ExifInterface(sourcePath)
+    val dst = ExifInterface(destPath)
+    val tagsToCopy = arrayOf(
+        ExifInterface.TAG_DATETIME,
+        ExifInterface.TAG_DATETIME_ORIGINAL,
+        ExifInterface.TAG_DATETIME_DIGITIZED,
+        ExifInterface.TAG_MAKE,
+        ExifInterface.TAG_MODEL,
+        ExifInterface.TAG_F_NUMBER,
+        ExifInterface.TAG_EXPOSURE_TIME,
+        ExifInterface.TAG_ISO_SPEED_RATINGS,
+        ExifInterface.TAG_FOCAL_LENGTH,
+        ExifInterface.TAG_FLASH,
+        ExifInterface.TAG_WHITE_BALANCE,
+        ExifInterface.TAG_GPS_LATITUDE,
+        ExifInterface.TAG_GPS_LATITUDE_REF,
+        ExifInterface.TAG_GPS_LONGITUDE,
+        ExifInterface.TAG_GPS_LONGITUDE_REF,
+        ExifInterface.TAG_GPS_ALTITUDE,
+        ExifInterface.TAG_GPS_ALTITUDE_REF,
+        ExifInterface.TAG_GPS_TIMESTAMP,
+        ExifInterface.TAG_GPS_DATESTAMP,
+        ExifInterface.TAG_GPS_PROCESSING_METHOD,
+        ExifInterface.TAG_SUBSEC_TIME,
+        ExifInterface.TAG_SUBSEC_TIME_ORIGINAL,
+        ExifInterface.TAG_SUBSEC_TIME_DIGITIZED,
+    )
+    for (tag in tagsToCopy) {
+        src.getAttribute(tag)?.let { dst.setAttribute(tag, it) }
+    }
+    // Pixels are already in display orientation — strip the rotation tag.
+    dst.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+    dst.saveAttributes()
 }
 
 /**

--- a/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/ImageUtils.android.kt
+++ b/shared/src/androidMain/kotlin/io/github/yahiaangelo/filmsimulator/util/ImageUtils.android.kt
@@ -2,8 +2,10 @@ package io.github.yahiaangelo.filmsimulator.util
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.ImageDecoder
 import android.graphics.Matrix
 import android.media.ExifInterface
+import android.os.Build
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
@@ -13,6 +15,7 @@ import util.systemTemporaryPath
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.io.RandomAccessFile
 import kotlin.random.Random
 
 /**
@@ -70,44 +73,242 @@ actual suspend fun ImageBitmap.readPixels(): ByteArray {
 
 actual suspend fun fixImageOrientation(image: String): String = image
 
-actual suspend fun convertImageToJpeg(image: String){
+actual suspend fun convertImageToJpeg(image: String) {
     val imagePath = "$systemTemporaryPath/$image"
     try {
         withContext(Dispatchers.IO) {
-            // Load the .heic image as a Bitmap
-            val heicBitmap = BitmapFactory.decodeFile(imagePath)
-
-            // Check if Bitmap is successfully loaded
-            if (heicBitmap != null) {
-                // Read the EXIF orientation metadata
-                val exif = ExifInterface(imagePath)
-                val orientation = exif.getAttributeInt(
-                    ExifInterface.TAG_ORIENTATION,
-                    ExifInterface.ORIENTATION_NORMAL
-                )
-
-                // Adjust the Bitmap's orientation
-                val adjustedBitmap = adjustBitmapOrientation(heicBitmap, orientation)
-
-                // Create an output file
-                val outputFile = File(imagePath)
-                val outputStream = FileOutputStream(outputFile)
-
-                // Compress the Bitmap into JPEG format and save it to the output file
-                adjustedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
-
-                // Close the stream
-                outputStream.flush()
-                outputStream.close()
-
-                println("Conversion successful. JPEG file saved at: $imagePath")
+            // Sniff the file by its first bytes instead of trusting the extension —
+            // the picker pipeline always writes the cached source as "image.jpeg"
+            // regardless of source format, so a DNG on disk is named .jpeg here.
+            val isTiff = runCatching { isTiffMagic(File(imagePath)) }.getOrDefault(false)
+            val bitmap: Bitmap? = if (isTiff) {
+                // For RAW/DNG (TIFF containers) we walk the structure ourselves and
+                // pull the largest embedded JPEG preview, then apply IFD0 orientation
+                // since the embedded preview is stored unrotated. Stock Android
+                // decoders either pick a smaller preview or skip orientation entirely
+                // for DNGs from some cameras.
+                decodeRawViaEmbeddedPreview(imagePath)
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                runCatching {
+                    val source = ImageDecoder.createSource(File(imagePath))
+                    ImageDecoder.decodeBitmap(source) { decoder, _, _ ->
+                        decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+                        decoder.isMutableRequired = false
+                    }
+                }.getOrNull() ?: decodeWithBitmapFactoryAndFixOrientation(imagePath)
             } else {
-                println("Failed to decode .heic file. Ensure the input file is valid.")
+                decodeWithBitmapFactoryAndFixOrientation(imagePath)
+            }
+
+            if (bitmap == null) {
+                println("Failed to decode image at $imagePath")
+                return@withContext
+            }
+
+            FileOutputStream(File(imagePath)).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
+                out.flush()
             }
         }
     } catch (e: Exception) {
         e.printStackTrace()
         println("Error during conversion: ${e.message}")
+    }
+}
+
+private fun isTiffMagic(file: File): Boolean {
+    if (!file.exists() || file.length() < 4) return false
+    return RandomAccessFile(file, "r").use { raf ->
+        val head = ByteArray(4)
+        raf.readFully(head)
+        // "II" + 0x2A 0x00 (little-endian TIFF) or "MM" + 0x00 0x2A (big-endian)
+        (head[0] == 0x49.toByte() && head[1] == 0x49.toByte() &&
+            head[2] == 0x2A.toByte() && head[3] == 0x00.toByte()) ||
+        (head[0] == 0x4D.toByte() && head[1] == 0x4D.toByte() &&
+            head[2] == 0x00.toByte() && head[3] == 0x2A.toByte())
+    }
+}
+
+private fun decodeRawViaEmbeddedPreview(imagePath: String): Bitmap? {
+    val file = File(imagePath)
+    val parsed = runCatching { extractLargestEmbeddedJpegFromRaw(file) }.getOrNull()
+    val bitmap = if (parsed != null) {
+        BitmapFactory.decodeByteArray(parsed.jpegBytes, 0, parsed.jpegBytes.size)
+    } else {
+        // If TIFF walking didn't find anything useful, fall back to whatever Skia
+        // can decode directly — better than failing outright.
+        BitmapFactory.decodeFile(imagePath)
+    } ?: return null
+
+    // Trust the TIFF orientation read from our own parser when we have it.
+    // android.media.ExifInterface's DNG handling is inconsistent across versions
+    // (it returns NORMAL on some devices even when the IFD0 orientation tag is
+    // present), so we prefer the value we parsed ourselves and only fall back
+    // to ExifInterface if parsing failed.
+    val orientation = parsed?.orientation
+        ?: runCatching {
+            ExifInterface(imagePath).getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL,
+            )
+        }.getOrDefault(ExifInterface.ORIENTATION_NORMAL)
+    return adjustBitmapOrientation(bitmap, orientation)
+}
+
+private fun decodeWithBitmapFactoryAndFixOrientation(imagePath: String): Bitmap? {
+    val bm = BitmapFactory.decodeFile(imagePath) ?: return null
+    val orientation = runCatching {
+        ExifInterface(imagePath).getAttributeInt(
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.ORIENTATION_NORMAL,
+        )
+    }.getOrDefault(ExifInterface.ORIENTATION_NORMAL)
+    return adjustBitmapOrientation(bm, orientation)
+}
+
+private data class ParsedRawPreview(val jpegBytes: ByteArray, val orientation: Int)
+
+/**
+ * Walks the TIFF/DNG structure of a RAW file to find the largest embedded JPEG
+ * preview. DNG (and most RAWs) are TIFF containers: IFD0 typically holds a small
+ * thumbnail (and for "RAW+JPEG" Pixel captures, that's the *only* JPEG — the
+ * full image lives in the companion .jpg file, not the .dng). SubIFDs may hold
+ * a larger preview on cameras that embed one. We walk every IFD/SubIFD, collect
+ * candidates with JPEG-encoded pixels, and pick the largest by dimensions.
+ *
+ * Also returns the IFD0 orientation tag — needed because embedded preview JPEGs
+ * are stored unrotated; the rotation lives on the parent TIFF.
+ */
+private fun extractLargestEmbeddedJpegFromRaw(file: File): ParsedRawPreview? {
+    RandomAccessFile(file, "r").use { raf ->
+        val fileLen = raf.length()
+        if (fileLen < 8) return null
+
+        val header = ByteArray(8)
+        raf.readFully(header)
+        val littleEndian = when {
+            header[0] == 0x49.toByte() && header[1] == 0x49.toByte() -> true  // 'II'
+            header[0] == 0x4D.toByte() && header[1] == 0x4D.toByte() -> false // 'MM'
+            else -> return null
+        }
+
+        fun u16(buf: ByteArray, o: Int): Int {
+            val b0 = buf[o].toInt() and 0xff
+            val b1 = buf[o + 1].toInt() and 0xff
+            return if (littleEndian) (b1 shl 8) or b0 else (b0 shl 8) or b1
+        }
+        fun u32(buf: ByteArray, o: Int): Long {
+            val b0 = buf[o].toLong() and 0xff
+            val b1 = buf[o + 1].toLong() and 0xff
+            val b2 = buf[o + 2].toLong() and 0xff
+            val b3 = buf[o + 3].toLong() and 0xff
+            return if (littleEndian) (b3 shl 24) or (b2 shl 16) or (b1 shl 8) or b0
+                   else (b0 shl 24) or (b1 shl 16) or (b2 shl 8) or b3
+        }
+
+        if (u16(header, 2) != 42) return null
+        val firstIfdOffset = u32(header, 4)
+
+        fun readAt(offset: Long, size: Int): ByteArray? {
+            if (offset < 0 || size <= 0 || offset + size > fileLen) return null
+            raf.seek(offset)
+            val buf = ByteArray(size)
+            raf.readFully(buf)
+            return buf
+        }
+
+        data class Preview(val offset: Long, val length: Long, val area: Long)
+        val previews = mutableListOf<Preview>()
+        val toProcess = ArrayDeque<Long>().apply { add(firstIfdOffset) }
+        val seen = HashSet<Long>()
+        var ifdsExamined = 0
+        var ifd0Orientation = ExifInterface.ORIENTATION_NORMAL
+
+        val firstIfdSeen = firstIfdOffset
+        while (toProcess.isNotEmpty() && ifdsExamined < 64) {
+            val ifdOffset = toProcess.removeFirst()
+            if (!seen.add(ifdOffset)) continue
+            ifdsExamined++
+
+            val countBuf = readAt(ifdOffset, 2) ?: continue
+            val numEntries = u16(countBuf, 0)
+            if (numEntries <= 0 || numEntries > 65535) continue
+            val entriesSize = numEntries * 12
+            val entriesBuf = readAt(ifdOffset + 2, entriesSize) ?: continue
+
+            var width = 0
+            var height = 0
+            var compression = 0
+            var stripOffsets = -1L
+            var stripByteCounts = -1L
+            var jpegOffset = -1L
+            var jpegLength = -1L
+
+            for (i in 0 until numEntries) {
+                val base = i * 12
+                val tag = u16(entriesBuf, base)
+                val type = u16(entriesBuf, base + 2)
+                val count = u32(entriesBuf, base + 4)
+                val inlineOffset = base + 8
+
+                fun readScalar(): Long = when (type) {
+                    3 -> u16(entriesBuf, inlineOffset).toLong()
+                    4 -> u32(entriesBuf, inlineOffset)
+                    else -> u32(entriesBuf, inlineOffset)
+                }
+
+                when (tag) {
+                    256 -> width = readScalar().toInt()        // ImageWidth
+                    257 -> height = readScalar().toInt()       // ImageLength
+                    259 -> compression = readScalar().toInt()  // Compression
+                    273 -> stripOffsets = if (count == 1L) readScalar()
+                                          else u32(entriesBuf, inlineOffset)
+                    274 -> {                                   // Orientation (only trust IFD0's)
+                        if (ifdOffset == firstIfdSeen) {
+                            ifd0Orientation = readScalar().toInt()
+                        }
+                    }
+                    279 -> stripByteCounts = if (count == 1L) readScalar()
+                                             else u32(entriesBuf, inlineOffset)
+                    330 -> {                                   // SubIFDs
+                        if (count == 1L) {
+                            toProcess.add(readScalar())
+                        } else {
+                            val arrayOffset = u32(entriesBuf, inlineOffset)
+                            val cap = count.coerceAtMost(16L).toInt()
+                            val subBuf = readAt(arrayOffset, cap * 4)
+                            if (subBuf != null) {
+                                for (j in 0 until cap) {
+                                    val sub = u32(subBuf, j * 4)
+                                    if (sub > 0) toProcess.add(sub)
+                                }
+                            }
+                        }
+                    }
+                    513 -> jpegOffset = readScalar()           // JPEGInterchangeFormat
+                    514 -> jpegLength = readScalar()           // JPEGInterchangeFormatLength
+                }
+            }
+
+            val nextIfdBuf = readAt(ifdOffset + 2 + entriesSize, 4)
+            if (nextIfdBuf != null) {
+                val nextIfd = u32(nextIfdBuf, 0)
+                if (nextIfd > 0) toProcess.add(nextIfd)
+            }
+
+            if (jpegOffset > 0 && jpegLength > 0 && jpegOffset + jpegLength <= fileLen) {
+                previews.add(Preview(jpegOffset, jpegLength, width.toLong() * height.toLong()))
+            } else if (compression == 7 && stripOffsets > 0 && stripByteCounts > 0 &&
+                       stripOffsets + stripByteCounts <= fileLen) {
+                previews.add(Preview(stripOffsets, stripByteCounts,
+                    width.toLong() * height.toLong()))
+            }
+        }
+
+        val best = previews.maxByOrNull { if (it.area > 0) it.area else it.length }
+            ?: return null
+        val jpegBytes = readAt(best.offset, best.length.toInt()) ?: return null
+        return ParsedRawPreview(jpegBytes, ifd0Orientation)
     }
 }
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,11 @@
     <string name="updating_luts_list">Updating Luts list</string>
     <string name="settings">Settings</string>
     <string name="image_export_quality">Image Export Quality</string>
+    <string name="export_format">Export Format</string>
+    <string name="export_format_jpeg">JPEG</string>
+    <string name="export_format_original">Original (keep metadata)</string>
+    <string name="export_format_summary_jpeg">Always export as JPEG (no metadata preserved)</string>
+    <string name="export_format_summary_original">Export in source format with EXIF metadata</string>
     <string name="about">About</string>
     <string name="app_version">App Version</string>
     <string name="developer">Developer</string>

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/local/SettingsStorage.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/local/SettingsStorage.kt
@@ -1,11 +1,13 @@
 package io.github.yahiaangelo.filmsimulator.data.source.local
 
 import io.github.yahiaangelo.filmsimulator.screens.settings.DefaultPickerType
+import io.github.yahiaangelo.filmsimulator.screens.settings.ExportFormat
 
 
 interface SettingsStorage {
 
     var exportQuality: Int
+    var exportFormat: ExportFormat
     var defaultPicker: DefaultPickerType
     var hasShownLutDownloadDialog: Boolean
     fun defaultPickerListener(callback: (DefaultPickerType) -> Unit)
@@ -15,6 +17,7 @@ interface SettingsStorage {
 
 enum class StorageKeys {
     EXPORT_QUALITY,
+    EXPORT_FORMAT,
     HAS_SHOWN_LUT_DOWNLOAD_DIALOG,
     DEFAULT_PICKER;
     val key get() = this.name

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/local/SettingsStorageImpl.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/data/source/local/SettingsStorageImpl.kt
@@ -9,6 +9,7 @@ import com.russhwolf.settings.set
 import io.github.yahiaangelo.filmsimulator.PlatformName
 import io.github.yahiaangelo.filmsimulator.getPlatform
 import io.github.yahiaangelo.filmsimulator.screens.settings.DefaultPickerType
+import io.github.yahiaangelo.filmsimulator.screens.settings.ExportFormat
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -36,6 +37,14 @@ class SettingsStorageImpl : SettingsStorage {
         get() = observableSettings[StorageKeys.EXPORT_QUALITY.key] ?: 90
         set(value) {
             observableSettings[StorageKeys.EXPORT_QUALITY.key] = value
+        }
+
+    override var exportFormat: ExportFormat
+        get() = ExportFormat.valueOf(
+            observableSettings[StorageKeys.EXPORT_FORMAT.key] ?: ExportFormat.JPEG.name
+        )
+        set(value) {
+            observableSettings[StorageKeys.EXPORT_FORMAT.key] = value.name
         }
     override var defaultPicker: DefaultPickerType
         get() = DefaultPickerType.valueOf(

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
@@ -421,6 +422,7 @@ data class HomeScreen(
             },
             sheetState = sheetState,
             dragHandle = {},
+            scrimColor = Color.Transparent,
         ) {
             Box(
                 modifier = Modifier

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -82,12 +82,11 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.core.screen.uniqueScreenKey
-import cafe.adriel.voyager.koin.getScreenModel
+import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
-import coil3.compose.SubcomposeAsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
@@ -152,7 +151,7 @@ data class HomeScreen(
         val navigator = LocalNavigator.currentOrThrow
         val snackbarHostState = remember { SnackbarHostState() }
 
-        val vm = getScreenModel<HomeScreenModel>()
+        val vm = koinScreenModel<HomeScreenModel>()
         val uiState by vm.uiState.collectAsState()
 
         val singleImagePicker = rememberFilePickerLauncher(

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -85,13 +85,15 @@ import cafe.adriel.voyager.core.screen.uniqueScreenKey
 import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import androidx.compose.ui.graphics.decodeToImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import com.github.panpf.zoomimage.CoilZoomAsyncImage
-import com.github.panpf.zoomimage.rememberCoilZoomState
+import com.github.panpf.zoomimage.ZoomImage
+import com.github.panpf.zoomimage.compose.rememberZoomState
 
 import film_simulator.shared.generated.resources.Res
 import film_simulator.shared.generated.resources.film
@@ -255,7 +257,7 @@ data class HomeScreen(
         state: HomeUiState,
         modifier: Modifier = Modifier
     ) {
-        val zoomState = rememberCoilZoomState()
+        val zoomState = rememberZoomState()
         Column(modifier = modifier.padding(horizontal = 18.dp)) {
             Spacer(modifier = Modifier.size(23.dp))
             Box(modifier = Modifier.fillMaxWidth()) {
@@ -271,19 +273,15 @@ data class HomeScreen(
                 ) {
                     Box(modifier = Modifier.fillMaxSize()) {
                         state.previewImage?.let { bytes ->
-                            val cacheKey = "preview-${state.previewToken}"
-                            CoilZoomAsyncImage(
+                            val painter = remember(bytes) {
+                                BitmapPainter(bytes.decodeToImageBitmap())
+                            }
+                            ZoomImage(
                                 modifier = Modifier.fillMaxSize(),
                                 zoomState = zoomState,
-                                model = ImageRequest.Builder(LocalPlatformContext.current)
-                                    .data(bytes)
-                                    .memoryCacheKey(cacheKey)
-                                    .diskCacheKey(cacheKey)
-                                    .memoryCachePolicy(CachePolicy.DISABLED)
-                                    .diskCachePolicy(CachePolicy.DISABLED)
-                                    .build(),
+                                painter = painter,
                                 contentDescription = null,
-                                scrollBar = null
+                                scrollBar = null,
                             )
                         } ?: IconButton(
                             modifier = Modifier.align(Alignment.Center).size(150.dp),

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -128,7 +128,9 @@ import io.github.yahiaangelo.filmsimulator.view.LutDownloadDialog
 import io.github.yahiaangelo.filmsimulator.view.LutDownloadProgressDialog
 import io.github.yahiaangelo.filmsimulator.view.ProgressDialog
 import io.github.yahiaangelo.filmsimulator.view.SettingsSlider
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import util.THUMBNAILS_DIR
@@ -273,16 +275,23 @@ data class HomeScreen(
                 ) {
                     Box(modifier = Modifier.fillMaxSize()) {
                         state.previewImage?.let { bytes ->
-                            val painter = remember(bytes) {
-                                BitmapPainter(bytes.decodeToImageBitmap())
+                            // Decode off the main thread; keep the previous painter visible
+                            // until the new one is ready so the toggle/preview swap stays smooth.
+                            var painter by remember { mutableStateOf<BitmapPainter?>(null) }
+                            LaunchedEffect(bytes) {
+                                painter = withContext(Dispatchers.Default) {
+                                    BitmapPainter(bytes.decodeToImageBitmap())
+                                }
                             }
-                            ZoomImage(
-                                modifier = Modifier.fillMaxSize(),
-                                zoomState = zoomState,
-                                painter = painter,
-                                contentDescription = null,
-                                scrollBar = null,
-                            )
+                            painter?.let { p ->
+                                ZoomImage(
+                                    modifier = Modifier.fillMaxSize(),
+                                    zoomState = zoomState,
+                                    painter = p,
+                                    contentDescription = null,
+                                    scrollBar = null,
+                                )
+                            }
                         } ?: IconButton(
                             modifier = Modifier.align(Alignment.Center).size(150.dp),
                             onClick = state.onImageChooseClick

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -80,6 +80,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
+import cafe.adriel.voyager.core.screen.uniqueScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -135,6 +137,11 @@ import util.systemTemporaryPath
 data class HomeScreen(
     val userMessage: String = ""
 ) : Screen {
+
+    // Workaround for voyager#546: without a unique key the AndroidScreenLifecycleOwner
+    // is reused across activity restarts and gets disposed mid-flight, causing the
+    // empty-LUTs UI and the "DESTROYED cannot be moved to STARTED" crash.
+    override val key: ScreenKey = uniqueScreenKey
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreenModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreenModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.withContext
 import org.koin.dsl.module
 import util.EDITED_IMAGE_FILE_NAME
 import util.IMAGE_FILE_NAME
+import util.ORIGINAL_IMAGE_FILE_PREFIX
 import util.THUMBNAILS_DIR
 import util.createDirectory
 import util.readImageFile
@@ -47,6 +48,17 @@ val homeScreenModule = module {
 
 /** Debounce window before re-rendering the preview after a slider change. */
 private const val PREVIEW_DEBOUNCE_MS = 25L
+
+/**
+ * Source formats that the Skia pipeline can't decode at full quality on its own —
+ * they need to be transcoded to JPEG first via the platform converter. For RAW
+ * formats this also ensures we read the embedded full-size preview rather than
+ * the tiny thumbnail BitmapFactory returns by default (Pixel DNGs etc.).
+ */
+private val formatsNeedingConversion = setOf(
+    "heic", "heif",
+    "dng", "raw", "cr2", "nef", "orf", "arw", "raf", "pef", "sr2", "rw2",
+)
 
 /** JPEG quality used for the preview pipeline — lower than export to keep encode fast. */
 private const val PREVIEW_QUALITY = 80
@@ -127,6 +139,8 @@ data class HomeScreenModel(
     private var currentLutBytes: ByteArray? = null
     private var currentAdjustments: ImageAdjustments = ImageAdjustments()
     private var currentThumbnailJob: Job? = null
+    /** Filename in app cache holding the user's unmodified original picked image, with original extension. */
+    private var originalImageFileName: String? = null
 
     private data class PreviewRequest(
         val sourceKey: Int,
@@ -293,8 +307,15 @@ data class HomeScreenModel(
                 return
             }
             screenModelScope.launch {
-                saveImageFile(IMAGE_FILE_NAME, platformFile.readBytes())
-                if (arrayOf("heic", "heif").contains(platformFile.extension.lowercase())) {
+                val originalBytes = platformFile.readBytes()
+                // Stash the raw original (with original extension) so export can read its
+                // EXIF / detect format when "original format" export is selected.
+                val originalName = "$ORIGINAL_IMAGE_FILE_PREFIX.${platformFile.extension.lowercase()}"
+                saveImageFile(originalName, originalBytes)
+                originalImageFileName = originalName
+
+                saveImageFile(IMAGE_FILE_NAME, originalBytes)
+                if (formatsNeedingConversion.contains(platformFile.extension.lowercase())) {
                     convertImageToJpeg(IMAGE_FILE_NAME)
                 }
                 fixImageOrientation(image = IMAGE_FILE_NAME)
@@ -375,7 +396,12 @@ data class HomeScreenModel(
                 }
 
                 updateUiState { it.copy(loadingMessage = "Saving to gallery...") }
-                saveImageToGallery(EDITED_IMAGE_FILE_NAME, appContext = AppContext)
+                saveImageToGallery(
+                    image = EDITED_IMAGE_FILE_NAME,
+                    appContext = AppContext,
+                    format = settingsRepository.getSettings().exportFormat,
+                    originalImage = originalImageFileName,
+                )
 
                 updateUiState { it.copy(userMessage = "Image exported successfully with all effects applied.") }
             } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
+import cafe.adriel.voyager.core.screen.uniqueScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -50,6 +52,11 @@ import film_simulator.shared.generated.resources.app_version
 import film_simulator.shared.generated.resources.contact
 import film_simulator.shared.generated.resources.default_picker
 import film_simulator.shared.generated.resources.developer
+import film_simulator.shared.generated.resources.export_format
+import film_simulator.shared.generated.resources.export_format_jpeg
+import film_simulator.shared.generated.resources.export_format_original
+import film_simulator.shared.generated.resources.export_format_summary_jpeg
+import film_simulator.shared.generated.resources.export_format_summary_original
 import film_simulator.shared.generated.resources.files
 import film_simulator.shared.generated.resources.image_export_quality
 import film_simulator.shared.generated.resources.images
@@ -70,6 +77,9 @@ import sh.calvin.autolinktext.rememberAutoLinkText
 
 class SettingsScreen : Screen {
 
+    // See HomeScreen — workaround for voyager#546.
+    override val key: ScreenKey = uniqueScreenKey
+
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable
     override fun Content() {
@@ -77,6 +87,7 @@ class SettingsScreen : Screen {
         val scaffoldState = rememberScaffoldState()
         val snackbarHostState = remember { SnackbarHostState() }
         val showDefaultPickerDialog = remember { mutableStateOf(false) }
+        val showExportFormatDialog = remember { mutableStateOf(false) }
         val vm = getScreenModel<SettingsScreenModel>()
         val uiState by vm.uiState.collectAsState()
 
@@ -129,6 +140,23 @@ class SettingsScreen : Screen {
                     onValueChange = vm::updateExportQualitySettings
                 )
                 Spacer(modifier = Modifier.padding(16.dp))
+                ListItem(
+                    modifier = Modifier.clickable {
+                        showExportFormatDialog.value = true
+                    },
+                    text = {
+                        Text(
+                            text = stringResource(Res.string.export_format),
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                    },
+                    secondaryText = {
+                        Text(
+                            text = stringResource(uiState.exportFormat.getString()),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    },
+                )
                 ListItem(
                     modifier = Modifier.clickable {
                         showDefaultPickerDialog.value = true
@@ -201,6 +229,85 @@ class SettingsScreen : Screen {
 
         DefaultPickerDialog(showDefaultPickerDialog.value, onItemClick = vm::updateDefaultPickerSettings) {
             showDefaultPickerDialog.value = false
+        }
+
+        ExportFormatDialog(showExportFormatDialog.value, onItemClick = vm::updateExportFormatSettings) {
+            showExportFormatDialog.value = false
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+    @Composable
+    fun ExportFormatDialog(
+        show: Boolean,
+        onItemClick: (ExportFormat) -> Unit,
+        onDismiss: () -> Unit
+    ) {
+        if (show) {
+            BasicAlertDialog(
+                onDismissRequest = onDismiss
+            ) {
+                Surface(
+                    modifier = Modifier.wrapContentWidth().wrapContentHeight(),
+                    shape = MaterialTheme.shapes.large,
+                    tonalElevation = AlertDialogDefaults.TonalElevation
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = stringResource(Res.string.export_format),
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        ListItem(
+                            text = {
+                                Text(
+                                    text = stringResource(Res.string.export_format_jpeg),
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            },
+                            secondaryText = {
+                                Text(
+                                    text = stringResource(Res.string.export_format_summary_jpeg),
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                onItemClick(ExportFormat.JPEG)
+                                onDismiss()
+                            }
+                        )
+                        ListItem(
+                            text = {
+                                Text(
+                                    text = stringResource(Res.string.export_format_original),
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            },
+                            secondaryText = {
+                                Text(
+                                    text = stringResource(Res.string.export_format_summary_original),
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            },
+                            modifier = Modifier.clickable {
+                                onItemClick(ExportFormat.ORIGINAL)
+                                onDismiss()
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        TextButton(
+                            modifier = Modifier.align(Alignment.End),
+                            onClick = onDismiss
+                        ) {
+                            Text(
+                                text = stringResource(Res.string.cancel),
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.core.screen.uniqueScreenKey
-import cafe.adriel.voyager.koin.getScreenModel
+import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import film_simulator.shared.generated.resources.Res
@@ -88,7 +88,7 @@ class SettingsScreen : Screen {
         val snackbarHostState = remember { SnackbarHostState() }
         val showDefaultPickerDialog = remember { mutableStateOf(false) }
         val showExportFormatDialog = remember { mutableStateOf(false) }
-        val vm = getScreenModel<SettingsScreenModel>()
+        val vm = koinScreenModel<SettingsScreenModel>()
         val uiState by vm.uiState.collectAsState()
 
         val lutDownloadManager = remember { getKoin().get<LutDownloadManager>() }
@@ -135,8 +135,8 @@ class SettingsScreen : Screen {
                 SettingsSlider(
                     name = stringResource(Res.string.image_export_quality),
                     value = uiState.exportQuality.toFloat(),
-                    steps = 4,
-                    range = 25f..100f,
+                    steps = 8,
+                    range = 10f..100f,
                     onValueChange = vm::updateExportQualitySettings
                 )
                 Spacer(modifier = Modifier.padding(16.dp))

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreenModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/settings/SettingsScreenModel.kt
@@ -3,6 +3,8 @@ package io.github.yahiaangelo.filmsimulator.screens.settings
 import cafe.adriel.voyager.core.model.ScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import film_simulator.shared.generated.resources.Res
+import film_simulator.shared.generated.resources.export_format_jpeg
+import film_simulator.shared.generated.resources.export_format_original
 import film_simulator.shared.generated.resources.files
 import film_simulator.shared.generated.resources.images
 import io.github.yahiaangelo.filmsimulator.data.source.SettingsRepository
@@ -21,6 +23,7 @@ val settingsScreenModel = module {
 
 data class SettingsUiState(
     val exportQuality: Int = 0,
+    val exportFormat: ExportFormat = ExportFormat.JPEG,
     val defaultPicker: DefaultPickerType = DefaultPickerType.IMAGES,
     val userMessage: String? = null,
 )
@@ -36,17 +39,31 @@ enum class DefaultPickerType {
         }
     }
 }
+
+enum class ExportFormat {
+    JPEG,
+    ORIGINAL;
+
+    fun getString(): StringResource {
+        return when (this) {
+            JPEG -> Res.string.export_format_jpeg
+            ORIGINAL -> Res.string.export_format_original
+        }
+    }
+}
 class SettingsScreenModel(val repository: SettingsRepository): ScreenModel {
 
     private val _exportQuality: MutableStateFlow<Int> = MutableStateFlow(repository.getSettings().exportQuality)
+    private val _exportFormat: MutableStateFlow<ExportFormat> = MutableStateFlow(repository.getSettings().exportFormat)
     private val _defaultPicker: MutableStateFlow<DefaultPickerType> = MutableStateFlow(repository.getSettings().defaultPicker)
     private val _userMessage: MutableStateFlow<String?> = MutableStateFlow(null)
 
     val uiState: StateFlow<SettingsUiState> = combine(
-        _exportQuality, _defaultPicker, _userMessage
-    ) { exportQuality, defaultPicker, userMessage ->
+        _exportQuality, _exportFormat, _defaultPicker, _userMessage
+    ) { exportQuality, exportFormat, defaultPicker, userMessage ->
         SettingsUiState(
             exportQuality = exportQuality,
+            exportFormat = exportFormat,
             defaultPicker = defaultPicker,
             userMessage = userMessage
         )
@@ -67,6 +84,13 @@ class SettingsScreenModel(val repository: SettingsRepository): ScreenModel {
         screenModelScope.launch {
             repository.getSettings().exportQuality = quality.toInt()
             _exportQuality.emit(quality.toInt())
+        }
+    }
+
+    fun updateExportFormatSettings(format: ExportFormat) {
+        screenModelScope.launch {
+            repository.getSettings().exportFormat = format
+            _exportFormat.emit(format)
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.kt
@@ -1,11 +1,13 @@
 package util
 
+import io.github.yahiaangelo.filmsimulator.screens.settings.ExportFormat
 import io.github.yahiaangelo.filmsimulator.util.AppContext
 import okio.Path
 
 const val IMAGE_FILE_NAME = "image.jpeg"
 const val EDITED_IMAGE_FILE_NAME = "image-new.jpeg"
 const val THUMBNAILS_DIR = "thumbnails"
+const val ORIGINAL_IMAGE_FILE_PREFIX = "image-original"
 
 expect val systemTemporaryPath: Path
 /**
@@ -24,9 +26,22 @@ expect suspend fun readImageFile(fileName: String): ByteArray
 expect fun saveLutFile(fileName: String, lut: ByteArray)
 
 /**
- * Export image to gallery
+ * Export image to gallery.
+ *
+ * @param image          Filename (in app cache) holding the *processed* JPEG bytes to export.
+ * @param appContext     Platform context.
+ * @param format         Whether to export as JPEG (re-encode, no metadata) or in the
+ *                       original source format with EXIF metadata preserved.
+ * @param originalImage  Filename (in app cache) holding the *unmodified* original source
+ *                       bytes — used to read EXIF / detect source format. Ignored when
+ *                       [format] is [ExportFormat.JPEG] or this is null.
  */
-expect suspend fun saveImageToGallery(image: String, appContext: AppContext)
+expect suspend fun saveImageToGallery(
+    image: String,
+    appContext: AppContext,
+    format: ExportFormat = ExportFormat.JPEG,
+    originalImage: String? = null,
+)
 
 /**
  * Create a directory

--- a/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
@@ -2,7 +2,6 @@ package util
 
 import io.github.yahiaangelo.filmsimulator.screens.settings.ExportFormat
 import io.github.yahiaangelo.filmsimulator.util.AppContext
-import io.github.yahiaangelo.filmsimulator.util.toUIImage
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.IntVar
@@ -24,6 +23,8 @@ import platform.CoreFoundation.CFRelease
 import platform.CoreFoundation.CFURLRef
 import platform.CoreFoundation.kCFNumberIntType
 import platform.Foundation.CFBridgingRetain
+import platform.Foundation.NSDate
+import platform.Foundation.NSMutableArray
 import platform.Foundation.NSURL
 import platform.Foundation.NSUUID
 import platform.Foundation.NSTemporaryDirectory
@@ -34,11 +35,17 @@ import platform.ImageIO.CGImageSourceCopyPropertiesAtIndex
 import platform.ImageIO.CGImageSourceCreateWithURL
 import platform.ImageIO.CGImageSourceGetType
 import platform.ImageIO.kCGImagePropertyOrientation
+import platform.Photos.PHAssetCollection
+import platform.Photos.PHAssetCollectionChangeRequest
+import platform.Photos.PHAssetCollectionSubtypeAlbumRegular
+import platform.Photos.PHAssetCollectionTypeAlbum
 import platform.Photos.PHAssetCreationRequest
 import platform.Photos.PHAssetResourceTypePhoto
+import platform.Photos.PHObjectPlaceholder
 import platform.Photos.PHPhotoLibrary
-import platform.UIKit.UIImageWriteToSavedPhotosAlbum
 import kotlin.coroutines.resume
+
+private const val ALBUM_TITLE = "Film Simulator"
 
 actual val systemTemporaryPath = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
 actual fun saveImageFile(fileName: String, image: ByteArray) {
@@ -87,8 +94,13 @@ actual suspend fun saveImageToGallery(
         // Fall through to plain JPEG path on failure.
     }
 
-    val uiImage = readImageFile(image).toUIImage()!!
-    UIImageWriteToSavedPhotosAlbum(uiImage, null, null, null)
+    // Plain path: import the already-encoded processed JPEG straight into the
+    // app album via PhotoKit. Going through PhotoKit (rather than the older
+    // UIImageWriteToSavedPhotosAlbum) is what lets us place the asset inside a
+    // named album rather than dumping it into the camera roll.
+    val processedPath = "${systemTemporaryPath / image}"
+    val processedUrl = NSURL.fileURLWithPath(processedPath)
+    saveAssetToAppAlbum(processedUrl)
 }
 
 /**
@@ -160,6 +172,10 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
         if (!ok) return@withContext false
 
         suspendCancellableCoroutine<Boolean> { continuation ->
+            // Look up the album outside performChanges — the fetch is a read and
+            // performChanges is the write transaction. Inside the block we either
+            // mutate the existing album or create a new one.
+            val existingAlbum = findAppAlbum()
             PHPhotoLibrary.sharedPhotoLibrary().performChanges({
                 val request = PHAssetCreationRequest.creationRequestForAsset()
                 request.addResourceWithType(
@@ -167,6 +183,12 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
                     tmpUrl,
                     null,
                 )
+                // EXIF DateTimeOriginal stays intact inside the file (archival
+                // metadata) — but the PHAsset's creationDate is what Photos.app
+                // uses for sorting, so we set it to "now" so exports surface at
+                // the top of Recents and the app album.
+                request.setCreationDate(NSDate())
+                addAssetToAppAlbum(request.placeholderForCreatedAsset(), existingAlbum)
             }, completionHandler = { success, _ ->
                 runCatching { FileSystem.SYSTEM.delete(tmpPath.toPath()) }
                 destinationTmpPath = null
@@ -179,6 +201,64 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
         if (mergedProps != null) CFRelease(mergedProps)
         destinationTmpPath?.let { runCatching { FileSystem.SYSTEM.delete(it.toPath()) } }
     }
+}
+
+/**
+ * Save a file at [fileUrl] as a new asset in the app's Photos album,
+ * creating the album if it doesn't exist yet.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private suspend fun saveAssetToAppAlbum(fileUrl: NSURL): Boolean =
+    suspendCancellableCoroutine { continuation ->
+        val existingAlbum = findAppAlbum()
+        PHPhotoLibrary.sharedPhotoLibrary().performChanges({
+            val request = PHAssetCreationRequest.creationRequestForAsset()
+            request.addResourceWithType(PHAssetResourceTypePhoto, fileUrl, null)
+            // Stamp the asset's sort-time as "now" so the export lands at the
+            // top of Recents; the embedded EXIF capture date is left untouched.
+            request.setCreationDate(NSDate())
+            addAssetToAppAlbum(request.placeholderForCreatedAsset(), existingAlbum)
+        }, completionHandler = { success, _ ->
+            continuation.resume(success)
+        })
+    }
+
+/**
+ * Inside a [PHPhotoLibrary.performChanges] block, add the just-created asset
+ * (represented by [placeholder]) to the app album. If [existingAlbum] is null
+ * a new album with [ALBUM_TITLE] is created in the same transaction.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun addAssetToAppAlbum(
+    placeholder: PHObjectPlaceholder?,
+    existingAlbum: PHAssetCollection?,
+) {
+    if (placeholder == null) return
+    val albumRequest = if (existingAlbum != null) {
+        PHAssetCollectionChangeRequest.changeRequestForAssetCollection(existingAlbum)
+    } else {
+        PHAssetCollectionChangeRequest.creationRequestForAssetCollectionWithTitle(ALBUM_TITLE)
+    }
+    // PHAssetCollectionChangeRequest.addAssets expects an NSFastEnumeration —
+    // NSMutableArray adopts it. We wrap the single placeholder so the call works
+    // for the common one-asset-at-a-time export flow.
+    val assets = NSMutableArray()
+    assets.addObject(placeholder)
+    albumRequest?.addAssets(assets)
+}
+
+private fun findAppAlbum(): PHAssetCollection? {
+    val result = PHAssetCollection.fetchAssetCollectionsWithType(
+        PHAssetCollectionTypeAlbum,
+        PHAssetCollectionSubtypeAlbumRegular,
+        null,
+    )
+    val count = result.count.toInt()
+    for (i in 0 until count) {
+        val collection = result.objectAtIndex(i.toULong()) as? PHAssetCollection
+        if (collection?.localizedTitle == ALBUM_TITLE) return collection
+    }
+    return null
 }
 
 private fun extensionForExtension(srcExt: String): String = when (srcExt) {

--- a/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
@@ -1,14 +1,44 @@
 package util
 
+import io.github.yahiaangelo.filmsimulator.screens.settings.ExportFormat
 import io.github.yahiaangelo.filmsimulator.util.AppContext
 import io.github.yahiaangelo.filmsimulator.util.toUIImage
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import okio.FileSystem
 import okio.Path.Companion.toPath
+import platform.CoreFoundation.CFDictionaryCreateMutableCopy
+import platform.CoreFoundation.CFDictionarySetValue
+import platform.CoreFoundation.CFMutableDictionaryRef
+import platform.CoreFoundation.CFNumberCreate
+import platform.CoreFoundation.CFRelease
+import platform.CoreFoundation.CFURLRef
+import platform.CoreFoundation.kCFNumberIntType
+import platform.Foundation.CFBridgingRetain
+import platform.Foundation.NSURL
+import platform.Foundation.NSUUID
+import platform.Foundation.NSTemporaryDirectory
+import platform.ImageIO.CGImageDestinationAddImageFromSource
+import platform.ImageIO.CGImageDestinationCreateWithURL
+import platform.ImageIO.CGImageDestinationFinalize
+import platform.ImageIO.CGImageSourceCopyPropertiesAtIndex
+import platform.ImageIO.CGImageSourceCreateWithURL
+import platform.ImageIO.CGImageSourceGetType
+import platform.ImageIO.kCGImagePropertyOrientation
+import platform.Photos.PHAssetCreationRequest
+import platform.Photos.PHAssetResourceTypePhoto
+import platform.Photos.PHPhotoLibrary
 import platform.UIKit.UIImageWriteToSavedPhotosAlbum
+import kotlin.coroutines.resume
 
 actual val systemTemporaryPath = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
 actual fun saveImageFile(fileName: String, image: ByteArray) {
@@ -43,10 +73,122 @@ suspend fun deleteFile(filePath: String) {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-actual suspend fun saveImageToGallery(image: String, appContext: AppContext) {
-  val uiImage = readImageFile(image).toUIImage()!!
+actual suspend fun saveImageToGallery(
+    image: String,
+    appContext: AppContext,
+    format: ExportFormat,
+    originalImage: String?,
+) {
+    if (format == ExportFormat.ORIGINAL && originalImage != null) {
+        val ok = runCatching {
+            saveImageWithOriginalFormatAndMetadata(image, originalImage)
+        }.getOrDefault(false)
+        if (ok) return
+        // Fall through to plain JPEG path on failure.
+    }
 
-  UIImageWriteToSavedPhotosAlbum(uiImage, null, null, null)
+    val uiImage = readImageFile(image).toUIImage()!!
+    UIImageWriteToSavedPhotosAlbum(uiImage, null, null, null)
+}
+
+/**
+ * Re-encode the processed image into the original file's UTI (HEIC/JPEG/PNG/…) with
+ * its EXIF/GPS/TIFF metadata embedded, then import the resulting file into Photos
+ * via PhotoKit so the metadata survives.
+ *
+ * Implementation uses file-URL-based ImageIO so we work with toll-free-bridged
+ * NSURL ↔ CFURLRef via [CFBridgingRetain]. Returns false on any failure so the
+ * caller can fall back to a plain JPEG save.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@Suppress("UNCHECKED_CAST")
+private suspend fun saveImageWithOriginalFormatAndMetadata(
+    processedImageFile: String,
+    originalImageFile: String,
+): Boolean = withContext(Dispatchers.IO) {
+    val originalPath = "${systemTemporaryPath / originalImageFile}"
+    val processedPath = "${systemTemporaryPath / processedImageFile}"
+
+    val originalUrl = NSURL.fileURLWithPath(originalPath)
+    val processedUrl = NSURL.fileURLWithPath(processedPath)
+
+    // NSURL → CFURLRef. CFBridgingRetain transfers ownership; we balance with CFRelease.
+    val originalCfUrl = CFBridgingRetain(originalUrl) as CFURLRef? ?: return@withContext false
+    val processedCfUrl = CFBridgingRetain(processedUrl) as CFURLRef?
+        ?: run { CFRelease(originalCfUrl); return@withContext false }
+
+    var destinationTmpPath: String? = null
+    var mergedProps: CFMutableDictionaryRef? = null
+
+    try {
+        val originalSource = CGImageSourceCreateWithURL(originalCfUrl, null)
+            ?: return@withContext false
+        val sourceUti = CGImageSourceGetType(originalSource) ?: return@withContext false
+
+        val processedSource = CGImageSourceCreateWithURL(processedCfUrl, null)
+            ?: return@withContext false
+
+        // Make a mutable copy of the source's properties and force Orientation = 1
+        // because processed pixels are already in display orientation.
+        val sourceProps = CGImageSourceCopyPropertiesAtIndex(originalSource, 0u, null)
+            ?: return@withContext false
+        mergedProps = CFDictionaryCreateMutableCopy(null, 0, sourceProps)
+            ?: return@withContext false
+        memScoped {
+            val one = alloc<IntVar>().apply { value = 1 }
+            val orientationNum = CFNumberCreate(null, kCFNumberIntType, one.ptr)
+            CFDictionarySetValue(mergedProps, kCGImagePropertyOrientation, orientationNum)
+            CFRelease(orientationNum)
+        }
+
+        val ext = extensionForExtension(
+            originalImageFile.substringAfterLast('.', "jpg").lowercase()
+        )
+        val tmpPath = NSTemporaryDirectory() + "export-${NSUUID().UUIDString}.$ext"
+        destinationTmpPath = tmpPath
+        val tmpUrl = NSURL.fileURLWithPath(tmpPath)
+        val tmpCfUrl = CFBridgingRetain(tmpUrl) as CFURLRef? ?: return@withContext false
+
+        val ok = try {
+            val destination = CGImageDestinationCreateWithURL(tmpCfUrl, sourceUti, 1u, null)
+                ?: return@withContext false
+            CGImageDestinationAddImageFromSource(destination, processedSource, 0u, mergedProps)
+            CGImageDestinationFinalize(destination)
+        } finally {
+            CFRelease(tmpCfUrl)
+        }
+        if (!ok) return@withContext false
+
+        suspendCancellableCoroutine<Boolean> { continuation ->
+            PHPhotoLibrary.sharedPhotoLibrary().performChanges({
+                val request = PHAssetCreationRequest.creationRequestForAsset()
+                request.addResourceWithType(
+                    PHAssetResourceTypePhoto,
+                    tmpUrl,
+                    null,
+                )
+            }, completionHandler = { success, _ ->
+                runCatching { FileSystem.SYSTEM.delete(tmpPath.toPath()) }
+                destinationTmpPath = null
+                continuation.resume(success)
+            })
+        }
+    } finally {
+        CFRelease(originalCfUrl)
+        CFRelease(processedCfUrl)
+        if (mergedProps != null) CFRelease(mergedProps)
+        destinationTmpPath?.let { runCatching { FileSystem.SYSTEM.delete(it.toPath()) } }
+    }
+}
+
+private fun extensionForExtension(srcExt: String): String = when (srcExt) {
+    "heic" -> "heic"
+    "heif" -> "heif"
+    "png" -> "png"
+    "webp" -> "webp"
+    "tiff", "tif" -> "tiff"
+    "jpg", "jpeg" -> "jpg"
+    else -> "jpg"
 }
 
 /**


### PR DESCRIPTION
This pull request introduces significant improvements to image export and RAW image handling on Android, as well as updates to export format settings and user interface strings. The main focus is to allow users to export images in their original format with metadata preserved, improve support for RAW/DNG files, and make export format configurable in settings.

**Image Export and Metadata Handling:**

* The `saveImageToGallery` function now supports exporting images in the original format (when available) with EXIF metadata preserved, or as JPEG, based on a new `ExportFormat` setting. EXIF metadata is copied for JPEG exports, and the exported file is saved in a dedicated directory with proper MIME type and extension.
* Added a helper function to copy EXIF tags from the original image to the exported JPEG, ensuring archival metadata is retained while resetting orientation.

**RAW/DNG and Image Decoding Enhancements:**

* The image conversion pipeline now detects RAW/DNG (TIFF) files by magic bytes rather than relying on file extensions. For such files, it extracts the largest embedded JPEG preview, applies correct orientation, and falls back to default decoding if necessary.
* Improved compatibility with various image formats by using `ImageDecoder` for newer Android versions and robust orientation correction for all decodings.

**Settings and User Interface:**

* Added a new `exportFormat` property to `SettingsStorage` and its implementation, allowing users to choose between always exporting as JPEG or preserving the original format with metadata. [[1]](diffhunk://#diff-20e8b94ff98eafa1b02ad9b3682255b7ca9d6f2d7b78a57829388fe58777248cR4-R10) [[2]](diffhunk://#diff-20e8b94ff98eafa1b02ad9b3682255b7ca9d6f2d7b78a57829388fe58777248cR20) [[3]](diffhunk://#diff-40d4ed1d1d67b14110a9f7840f810e52a142058f614e55084f2a923e24b02f29R12) [[4]](diffhunk://#diff-40d4ed1d1d67b14110a9f7840f810e52a142058f614e55084f2a923e24b02f29R41-R48)
* Updated string resources to include user-facing descriptions for the new export format options.

**Dependency and Import Updates:**

* Added necessary imports for new functionality, including `ExifInterface`, `ImageDecoder`, and file I/O utilities. [[1]](diffhunk://#diff-8dbea393e5453396832daea0e9ce49a73cb09dd7a0ba3e5a59887f4dc588ec8bR6-R19) [[2]](diffhunk://#diff-64feec3cd16322cf14fee3f9d795472713a1c59e47d05e38fe35b082a5f01413R5-R8) [[3]](diffhunk://#diff-64feec3cd16322cf14fee3f9d795472713a1c59e47d05e38fe35b082a5f01413R18)

---

**Image Export Improvements**
- Enhanced `saveImageToGallery` to support exporting in original format with EXIF metadata, or as JPEG, based on user-selected `ExportFormat`. Added logic for proper MIME type, extension, and gallery integration.
- Added EXIF copying logic to preserve archival metadata in exported JPEGs, resetting orientation as needed.

**RAW/DNG and Image Decoding**
- Improved RAW/DNG (TIFF) detection and decoding by inspecting file magic bytes and extracting the largest embedded JPEG preview with correct orientation.
- Used `ImageDecoder` for modern Android versions and robust fallback orientation correction for all image decodings.

**Settings Enhancements**
- Introduced `exportFormat` setting in `SettingsStorage` and its implementation, allowing users to configure preferred export format. [[1]](diffhunk://#diff-20e8b94ff98eafa1b02ad9b3682255b7ca9d6f2d7b78a57829388fe58777248cR4-R10) [[2]](diffhunk://#diff-20e8b94ff98eafa1b02ad9b3682255b7ca9d6f2d7b78a57829388fe58777248cR20) [[3]](diffhunk://#diff-40d4ed1d1d67b14110a9f7840f810e52a142058f614e55084f2a923e24b02f29R12) [[4]](diffhunk://#diff-40d4ed1d1d67b14110a9f7840f810e52a142058f614e55084f2a923e24b02f29R41-R48)

**User Interface**
- Added and updated string resources for export format options and descriptions, improving user clarity in settings.

**Imports and Utilities**
- Added imports for `ExifInterface`, `ImageDecoder`, and file I/O utilities to support new functionality. [[1]](diffhunk://#diff-8dbea393e5453396832daea0e9ce49a73cb09dd7a0ba3e5a59887f4dc588ec8bR6-R19) [[2]](diffhunk://#diff-64feec3cd16322cf14fee3f9d795472713a1c59e47d05e38fe35b082a5f01413R5-R8) [[3]](diffhunk://#diff-64feec3cd16322cf14fee3f9d795472713a1c59e47d05e38fe35b082a5f01413R18)