### PR TITLE
Development merge

### DIFF
--- a/.github/actions/build.yml
+++ b/.github/actions/build.yml
@@ -1,0 +1,58 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4096M -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+
+jobs:
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Gradle setup
+        uses: ./.github/actions/gradle-setup
+
+      - name: Build Android debug APK
+        run: ./gradlew :mobile:assembleDebug
+
+      - name: Upload Android debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: mobile/build/outputs/apk/debug/*.apk
+  build-ios:
+    name: Build iOS simulator app
+    runs-on: macos-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Gradle setup
+        uses: ./.github/actions/gradle-setup
+
+      - name: Build iOS simulator app
+        run: |
+          xcodebuild build \
+          -project iosApp/iosApp.xcodeproj \
+          -configuration Debug \
+          -scheme iosApp \
+          -sdk iphonesimulator \
+          -derivedDataPath ./build \
+          -verbose
+
+      - name: Upload app folder
+        uses: actions/upload-artifact@v4
+        with:
+          name: iphonesimulator-app
+          path: build/Build/Products/Debug-iphonesimulator/*

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -1,0 +1,12 @@
+name: gradle-setup
+description: Setup Java and Gradle
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Java
+      uses: actions/setup-java@v4.0.0
+      with:
+        java-version: "17"
+        distribution: "temurin"
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5.0.0

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/ImageAdjustments.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/ImageAdjustments.kt
@@ -14,7 +14,11 @@ data class ImageAdjustments(
     val exposure: Float = 0f,
     val grain: Float = 0f,
     val chromaticAberration: Float = 0f,
-    /** LUT mix amount in 0..100 (percent). 100 = full LUT, 0 = pure source. */
+    /**
+     * LUT mix amount in 0..200 (percent). 0 = pure source, 100 = full LUT,
+     * values above 100 extrapolate past the LUT result to amplify subtle film
+     * stocks. The mix is clamped back into displayable range in the shader.
+     */
     val lutIntensity: Float = 100f,
 ) {
 

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/SkiaImageProcessor.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/SkiaImageProcessor.kt
@@ -76,7 +76,7 @@ class SkiaImageProcessor {
         val effect = RuntimeEffect.makeForShader(ImageProcessingShader.SHADER)
         val builder = RuntimeShaderBuilder(effect).apply {
             uniform("useLut", if (lutImage != null) 1f else 0f)
-            uniform("lutIntensity", (adjustments.lutIntensity / 100f).coerceIn(0f, 1f))
+            uniform("lutIntensity", (adjustments.lutIntensity / 100f).coerceIn(0f, 2f))
             uniform("lutSize", (lut?.size ?: 1).toFloat())
             uniform(
                 "imageScale",
@@ -89,8 +89,8 @@ class SkiaImageProcessor {
             // surfaces -20..20 (or 0..10 for grain/CA) which is a relic of the
             // earlier shader; keep the same feel by dividing similarly.
             uniform("exposure", (adjustments.exposure / 10f).coerceIn(-2f, 2f))
-            uniform("contrast", (adjustments.contrast / 20f).coerceIn(-1f, 1f))
-            uniform("shadows", (adjustments.shadows / 80f).coerceIn(-0.25f, 0.25f))
+            uniform("contrast", (adjustments.contrast / 40f).coerceIn(-0.5f, 0.5f))
+            uniform("shadows", (adjustments.shadows / 160f).coerceIn(-0.125f, 0.125f))
             uniform("highlights", (adjustments.highlights / 40f).coerceIn(-0.5f, 0.5f))
             uniform("saturation", (adjustments.saturation / 20f).coerceIn(-1f, 1f))
             uniform("temperature", (adjustments.temperature / 20f).coerceIn(-1f, 1f))

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/SkiaImageProcessor.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/SkiaImageProcessor.kt
@@ -3,6 +3,7 @@ package io.github.yahiaangelo.filmsimulator.image
 import io.github.yahiaangelo.filmsimulator.image.shaders.ImageProcessingShader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.EncodedImageFormat
@@ -16,6 +17,8 @@ import org.jetbrains.skia.RuntimeShaderBuilder
 import org.jetbrains.skia.SamplingMode
 import org.jetbrains.skia.Surface
 import kotlin.math.max
+import kotlin.math.roundToInt
+import kotlin.math.sqrt
 
 private const val DEFAULT_PREVIEW_MAX_DIMENSION = 960
 private const val LEGACY_THUMBNAIL_WIDTH = 320
@@ -56,6 +59,17 @@ class SkiaImageProcessor {
      * @param quality JPEG quality 0..100 for the encoded result.
      * @param grainSeed value mixed into the per-pixel grain hash so successive
      *   previews can stay stable while exports can pick a fresh pattern.
+     * @param highQualityGrain when true, the shader switches the grain block
+     *   to a film-emulation path (multi-octave FBM with per-channel cell
+     *   sizes, density-weighted soft-light blend). ~30-40x more expensive than
+     *   the cheap path, so enable for export only — preview should leave it
+     *   false to keep slider interaction smooth.
+     * @param onProgress when non-null, the render is split into tiles and this
+     *   callback is invoked with a 0..1 progress value after each tile. Each
+     *   tile also yields the worker coroutine so the main thread can render
+     *   the loading dialog's progress bar smoothly. Pass null to do a single
+     *   draw call (used for preview/thumbnail paths where a progress bar
+     *   would be overkill).
      */
     suspend fun process(
         imageBytes: ByteArray,
@@ -64,6 +78,8 @@ class SkiaImageProcessor {
         maxDimension: Int? = null,
         quality: Int = 95,
         grainSeed: Float = 0f,
+        highQualityGrain: Boolean = false,
+        onProgress: (suspend (Float) -> Unit)? = null,
     ): ByteArray? = withContext(Dispatchers.Default) {
         val source = sourceImage(imageBytes) ?: return@withContext null
         val lut = lutBytes?.let { bytes ->
@@ -96,6 +112,7 @@ class SkiaImageProcessor {
             uniform("temperature", (adjustments.temperature / 20f).coerceIn(-1f, 1f))
             uniform("grain", (adjustments.grain / 10f).coerceIn(0f, 1f))
             uniform("grainSeed", grainSeed)
+            uniform("grainQuality", if (highQualityGrain) 1f else 0f)
             uniform("chromaticAberration", (adjustments.chromaticAberration / 10f).coerceIn(0f, 1f))
 
             child(
@@ -124,7 +141,42 @@ class SkiaImageProcessor {
         val info = ImageInfo(outWidth, outHeight, ColorType.RGBA_8888, ColorAlphaType.PREMUL)
         val surface = Surface.makeRaster(info)
         val paint = Paint().apply { shader = builder.makeShader() }
-        surface.canvas.drawRect(Rect(0f, 0f, outWidth.toFloat(), outHeight.toFloat()), paint)
+
+        if (onProgress == null) {
+            surface.canvas.drawRect(Rect(0f, 0f, outWidth.toFloat(), outHeight.toFloat()), paint)
+        } else {
+            // Tile the render so the worker can yield between tiles. The shader
+            // is per-pixel (it uses fragCoord directly), so drawing a clipped
+            // rect produces the same pixels as one big draw — Skia handles the
+            // raster bucketing internally. We aim for ~32 tiles total which
+            // gives a smooth progress bar without too much per-tile overhead.
+            val targetTiles = 32
+            val aspect = outWidth.toFloat() / outHeight.toFloat()
+            val tilesX = max(1, sqrt(targetTiles * aspect).roundToInt())
+            val tilesY = max(1, (targetTiles.toFloat() / tilesX).roundToInt())
+            val tileW = (outWidth + tilesX - 1) / tilesX
+            val tileH = (outHeight + tilesY - 1) / tilesY
+            val total = (tilesX * tilesY).toFloat()
+            var done = 0
+            for (ty in 0 until tilesY) {
+                for (tx in 0 until tilesX) {
+                    val left = tx * tileW
+                    val top = ty * tileH
+                    val right = minOf(left + tileW, outWidth)
+                    val bottom = minOf(top + tileH, outHeight)
+                    surface.canvas.drawRect(
+                        Rect(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat()),
+                        paint,
+                    )
+                    done++
+                    onProgress(done / total)
+                    // yield() lets the dispatcher schedule other coroutines —
+                    // crucially, the ones forwarding UI state changes — so the
+                    // progress bar can actually animate while we render.
+                    yield()
+                }
+            }
+        }
 
         val snapshot = surface.makeImageSnapshot()
         snapshot.encodeToData(EncodedImageFormat.JPEG, quality)?.bytes

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/shaders/ImageProcessingShader.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/shaders/ImageProcessingShader.kt
@@ -39,6 +39,7 @@ internal object ImageProcessingShader {
         uniform float temperature;   // ~[-1, 1] (warm positive, cool negative)
         uniform float grain;         // 0..1 amplitude
         uniform float grainSeed;     // changes per export to vary noise pattern
+        uniform float grainQuality;  // 0 = cheap per-pixel hash (preview), 1 = film-emulation (export)
         uniform float chromaticAberration; // 0..1 normalized strength
 
         // ---- sRGB <-> linear ----
@@ -109,6 +110,43 @@ internal object ImageProcessingShader {
             float3 p3 = fract(float3(p.x, p.y, p.x) * 0.1031);
             p3 += dot(p3, p3.yzx + 33.33);
             return fract((p3.x + p3.y) * p3.z);
+        }
+
+        // Value noise: hash the 4 integer corners around p and smoothstep-interpolate.
+        // Output is band-limited to one cell width, which is what gives film grain
+        // its "size" — independent per-pixel hashes (the cheap path) live at the
+        // pixel Nyquist and read as digital noise, while value noise sampled at
+        // multi-pixel cell sizes reads as grain particles.
+        float vnoise(float2 p) {
+            float2 i = floor(p);
+            float2 f = fract(p);
+            float a = hash12(i);
+            float b = hash12(i + float2(1.0, 0.0));
+            float c = hash12(i + float2(0.0, 1.0));
+            float d = hash12(i + float2(1.0, 1.0));
+            float2 u = f * f * (3.0 - 2.0 * f);
+            return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+        }
+
+        // Fractal value noise — three octaves manually unrolled (SkSL loops have
+        // had compatibility quirks; unrolling is safe and the inner cost is tiny).
+        // Lacunarity 2.03 (not 2.0) breaks axis-aligned banding from doubling.
+        float fbm(float2 p) {
+            float v = 0.5     * vnoise(p);
+            p *= 2.03;
+            v +=     0.25    * vnoise(p);
+            p *= 2.03;
+            v +=     0.125   * vnoise(p);
+            return v / 0.875;  // re-normalize back to ~[0, 1]
+        }
+
+        // Pegtop soft-light blend — branch-free, photographic feel. When blend
+        // equals 0.5 the base is returned unchanged; departures from 0.5 lift or
+        // crush the base in a way that matches how density-on-negative behaves
+        // when projected, instead of the linear-add behaviour of the cheap path.
+        half3 softLight(half3 base, half3 blend) {
+            return (half3(1.0) - half3(2.0) * blend) * base * base
+                 + half3(2.0) * blend * base;
         }
 
         // Sample the source LUT-applied color at a normalized offset for CA.
@@ -201,27 +239,83 @@ internal object ImageProcessingShader {
                 srgb.b = clamp(srgb.b - half(temperature * 0.08), half(0.0), half(1.0));
             }
 
-            // Grain: sharp per-pixel hash, one tap per channel. Channels use
-            // large, mutually irrational offsets so the noise is completely
-            // decorrelated and reads as chromatic silver-halide grain instead of
-            // a luminance overlay. grainSeed shifts the entire field between
-            // renders. Coordinate is in output-pixel space so the noise is at the
-            // finest possible scale the render target can resolve — that
-            // high-frequency look is what reads as "random film grain" rather
-            // than the structured shimmer of interpolated noise.
+            // Grain. Two paths, selected by grainQuality (uniform branch — the
+            // shader takes one or the other for the whole render, no per-pixel
+            // branching).
+            //
+            // grainQuality == 0 (preview): cheap per-pixel hash, one tap per
+            // channel. Lives at the pixel Nyquist so it reads as digital noise
+            // when scrutinised, but it's a few ALU ops per pixel and runs fast
+            // on the slider drag.
+            //
+            // grainQuality == 1 (export): film-emulation stack. Per-channel
+            // FBM at different cell sizes (B largest, R smallest — matches
+            // real emulsion layer crystal sizes), density-weighted with a
+            // sqrt(L*(1-L)) curve biased toward mid-shadows (where film grain
+            // is actually most visible), then soft-light blended into the image
+            // so grain modulates density rather than adding to pixel values.
+            // ~30-40x the cost of the cheap path but only runs on export.
             if (grain > 0.0) {
-                float2 gp = fragCoord + float2(grainSeed * 137.7, grainSeed * 311.3);
-                float nR = hash12(gp + float2(  17.31,   91.07));
-                float nG = hash12(gp + float2(1313.71,  717.13));
-                float nB = hash12(gp + float2(2731.37, 4297.53));
-                half3 noise = half3(half(nR), half(nG), half(nB)) - half3(0.5);
+                if (grainQuality > 0.5) {
+                    // Cell sizes scale with grain (which is 0..1 from the slider):
+                    // at full strength the green-layer cell is ~3 px, which on a
+                    // 24 MP export reads as a coarse 35 mm-ISO-800-ish texture.
+                    float sizeG = mix(1.0, 3.0, grain);
+                    float sizeR = sizeG * 0.85;
+                    float sizeB = sizeG * 1.35;
 
-                half luma2 = dot(srgb, half3(0.2126, 0.7152, 0.0722));
-                half midtone = half(1.0) - abs(luma2 - half(0.5)) * half(1.4);
-                midtone = max(midtone, half(0.35));
+                    float2 seed = float2(grainSeed * 137.7, grainSeed * 311.3);
+                    float nR = fbm((fragCoord + seed + float2( 17.31,  91.07)) / sizeR);
+                    float nG = fbm((fragCoord + seed + float2(313.71, 717.13)) / sizeG);
+                    float nB = fbm((fragCoord + seed + float2(547.91, 991.37)) / sizeB);
 
-                srgb += noise * half(grain) * midtone;
-                srgb = clamp(srgb, half3(0.0), half3(1.0));
+                    // Mostly luma grain with a small chroma offset — pure
+                    // per-channel decorrelation produces rainbow speckle that
+                    // real film never does. 0.25 chroma keeps a hint of
+                    // emulsion-layer dye-cloud colour without going RGB-noisy.
+                    half nLuma = (half(nR) + half(nG) + half(nB)) / half(3.0);
+                    half3 nChan = half3(half(nR), half(nG), half(nB));
+                    half3 noise = mix(half3(nLuma), nChan, half(0.25)) - half3(0.5);
+
+                    // Yule-Nielsen-ish density curve: sqrt(L*(1-L)) peaks at
+                    // L=0.5 and rolls off cleanly toward both ends, then a
+                    // smoothstep tilt biases the peak toward mid-shadows where
+                    // emulsion grain is genuinely most visible. Floor at 0.25
+                    // so deep blacks and bright highlights still carry some
+                    // grain instead of going perfectly clean.
+                    half L = clamp(
+                        dot(srgb, half3(0.2126, 0.7152, 0.0722)),
+                        half(0.0),
+                        half(1.0)
+                    );
+                    half w = sqrt(max(L * (half(1.0) - L), half(0.0))) * half(2.0);
+                    w *= mix(half(1.2), half(0.7), smoothstep(half(0.5), half(0.95), L));
+                    w  = mix(half(0.25), half(1.0), w);
+
+                    // Additive blend with the density weight. Soft-light was
+                    // visually nicer but its non-linear curve asymptotes toward
+                    // neutral at high amplitudes, so even at slider=10 the
+                    // grain felt like ~2 on the cheap preview path. Additive
+                    // here gives us the same amplitude scaling as the preview
+                    // (noise * grain * weight) so the export now reads as the
+                    // intended slider strength — and the FBM, per-channel
+                    // sizes, and density curve still carry the "film" feel.
+                    srgb += noise * half(grain) * w;
+                    srgb = clamp(srgb, half3(0.0), half3(1.0));
+                } else {
+                    float2 gp = fragCoord + float2(grainSeed * 137.7, grainSeed * 311.3);
+                    float nR = hash12(gp + float2(  17.31,   91.07));
+                    float nG = hash12(gp + float2(1313.71,  717.13));
+                    float nB = hash12(gp + float2(2731.37, 4297.53));
+                    half3 noise = half3(half(nR), half(nG), half(nB)) - half3(0.5);
+
+                    half luma2 = dot(srgb, half3(0.2126, 0.7152, 0.0722));
+                    half midtone = half(1.0) - abs(luma2 - half(0.5)) * half(1.4);
+                    midtone = max(midtone, half(0.35));
+
+                    srgb += noise * half(grain) * midtone;
+                    srgb = clamp(srgb, half3(0.0), half3(1.0));
+                }
             }
 
             return half4(srgb, alpha);

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/shaders/ImageProcessingShader.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/image/shaders/ImageProcessingShader.kt
@@ -25,15 +25,15 @@ internal object ImageProcessingShader {
         uniform shader image;
         uniform shader lut;
         uniform float useLut;        // 0 = bypass LUT, 1 = apply
-        uniform float lutIntensity;  // 0..1 mix between source and LUT-processed
+        uniform float lutIntensity;  // 0..2 mix between source and LUT-processed; >1 extrapolates past the LUT
         uniform float lutSize;       // e.g. 33 for a 33^3 LUT
         uniform float2 imageScale;   // (srcW/outW, srcH/outH)
         uniform float2 resolution;   // output dimensions in pixels
 
         // Tonal — all pre-normalized by the caller.
         uniform float exposure;      // stops; ~[-2, 2]
-        uniform float contrast;      // multiplier offset; ~[-1, 1] (negative = flatter)
-        uniform float shadows;       // lifts (positive) / crushes (negative) shadow tones; ~[-0.25, 0.25]
+        uniform float contrast;      // multiplier offset; ~[-0.5, 0.5] (negative = flatter)
+        uniform float shadows;       // lifts (positive) / crushes (negative) shadow tones; ~[-0.125, 0.125]
         uniform float highlights;    // boosts (positive) / pulls down (negative) highlights; ~[-0.5, 0.5]
         uniform float saturation;    // ~[-1, 1]
         uniform float temperature;   // ~[-1, 1] (warm positive, cool negative)
@@ -146,8 +146,10 @@ internal object ImageProcessingShader {
                 alpha = raw.a;
             }
 
-            // Move to linear light for tonal ops.
-            half3 lin = srgbToLinear(color);
+            // Move to linear light for tonal ops. Clamp first: lutIntensity > 1
+            // extrapolates past the LUT and can push channels outside [0,1],
+            // which would feed pow() in srgbToLinear undefined inputs.
+            half3 lin = srgbToLinear(clamp(color, half3(0.0), half3(1.0)));
 
             // Exposure: stops (2^exposure multiplier in linear light).
             if (exposure != 0.0) {

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -349,8 +349,8 @@ data class HomeScreen(
                     name = "LUT Intensity",
                     value = state.imageAdjustments.lutIntensity,
                     onValueChange = state.onLutIntensityChange,
-                    range = 0f..100f,
-                    steps = 100
+                    range = 0f..200f,
+                    steps = 200
                 )
             }
             CenteredSettingsSlider(

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreen.kt
@@ -172,6 +172,7 @@ data class HomeScreen(
             selectedFilm = uiState.selectedFilm,
             isLoading = uiState.isLoading,
             loadingMessage = uiState.loadingMessage,
+            loadingProgress = uiState.loadingProgress,
             showBottomSheet = uiState.showBottomSheet,
             filmLuts = uiState.filmLuts,
             favoriteLuts = uiState.favoriteLuts,
@@ -250,7 +251,10 @@ data class HomeScreen(
         }
 
         if (homeScreenState.isLoading) {
-            ProgressDialog(loadingMessage = homeScreenState.loadingMessage)
+            ProgressDialog(
+                loadingMessage = homeScreenState.loadingMessage,
+                progress = homeScreenState.loadingProgress,
+            )
         }
     }
 

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreenModel.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/screens/home/HomeScreenModel.kt
@@ -72,6 +72,13 @@ data class HomeUiState(
     val selectedFilm: FilmLut? = null,
     val isLoading: Boolean = false,
     val loadingMessage: String = "",
+    /**
+     * 0..1 progress for the loading dialog. When null, the dialog falls back
+     * to its indeterminate spinner; when set, it renders a linear progress
+     * bar driven by this value. Only the export path populates this — other
+     * loading states (refresh, LUT load) leave it null.
+     */
+    val loadingProgress: Float? = null,
     val showBottomSheet: BottomSheetState = BottomSheetState.HIDDEN,
     val defaultPickerType: DefaultPickerType = DefaultPickerType.IMAGES,
     val filmLuts: List<FilmLut> = emptyList(),
@@ -379,6 +386,7 @@ data class HomeScreenModel(
                     it.copy(
                         isLoading = true,
                         loadingMessage = "Processing image with effects...",
+                        loadingProgress = 0f,
                     )
                 }
 
@@ -389,13 +397,22 @@ data class HomeScreenModel(
                     maxDimension = null,
                     quality = settingsRepository.getSettings().exportQuality,
                     grainSeed = (kotlin.random.Random.nextFloat() * 1000f),
+                    highQualityGrain = true,
+                    onProgress = { p ->
+                        updateUiState { it.copy(loadingProgress = p) }
+                    },
                 ) ?: throw IllegalStateException("Failed to process image")
 
                 withContext(Dispatchers.IO) {
                     saveImageFile(EDITED_IMAGE_FILE_NAME, exportedBytes)
                 }
 
-                updateUiState { it.copy(loadingMessage = "Saving to gallery...") }
+                // Switch back to indeterminate spinner for the gallery save —
+                // PhotoKit/MediaStore don't expose progress, so a fake bar
+                // there would be misleading.
+                updateUiState {
+                    it.copy(loadingMessage = "Saving to gallery...", loadingProgress = null)
+                }
                 saveImageToGallery(
                     image = EDITED_IMAGE_FILE_NAME,
                     appContext = AppContext,
@@ -407,7 +424,7 @@ data class HomeScreenModel(
             } catch (e: Exception) {
                 updateUiState { it.copy(userMessage = "Error exporting image: ${e.message}") }
             } finally {
-                updateUiState { it.copy(isLoading = false) }
+                updateUiState { it.copy(isLoading = false, loadingProgress = null) }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/view/ProgressDialog.kt
+++ b/shared/src/commonMain/kotlin/io/github/yahiaangelo/filmsimulator/view/ProgressDialog.kt
@@ -1,25 +1,34 @@
 package io.github.yahiaangelo.filmsimulator.view
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import kotlin.math.roundToInt
 
 @Composable
 fun ProgressDialog(
-    loadingMessage: String
+    loadingMessage: String,
+    progress: Float? = null,
 ) {
     Dialog(
         onDismissRequest = { },
@@ -28,14 +37,45 @@ fun ProgressDialog(
         Box(
             contentAlignment = Alignment.Center,
             modifier = Modifier
-                .size(150.dp)
+                .size(width = 220.dp, height = 150.dp)
                 .background(MaterialTheme.colorScheme.surface, shape = RoundedCornerShape(8.dp))
+                .padding(horizontal = 20.dp)
         ) {
-            Column {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+            Column(modifier = Modifier.fillMaxWidth()) {
+                if (progress != null) {
+                    // Smooth out the per-tile step changes — the underlying
+                    // value jumps in ~32 discrete steps, the animation makes
+                    // the bar glide instead of click-click-click.
+                    val animated by animateFloatAsState(
+                        targetValue = progress.coerceIn(0f, 1f),
+                        animationSpec = tween(durationMillis = 120),
+                        label = "exportProgress",
+                    )
+                    LinearProgressIndicator(
+                        progress = { animated },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.CenterHorizontally),
+                    )
+                    Spacer(modifier = Modifier.size(6.dp))
+                    Text(
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                        style = MaterialTheme.typography.labelMedium,
+                        text = "${(animated * 100f).roundToInt()}%",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .align(Alignment.CenterHorizontally),
+                    )
+                }
                 Spacer(modifier = Modifier.size(18.dp))
                 Text(
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.CenterHorizontally),
                     style = MaterialTheme.typography.titleSmall,
                     text = loadingMessage,
                     textAlign = TextAlign.Center,

--- a/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/io/github/yahiaangelo/filmsimulator/util/FileHandler.ios.kt
@@ -20,6 +20,7 @@ import platform.CoreFoundation.CFDictionarySetValue
 import platform.CoreFoundation.CFMutableDictionaryRef
 import platform.CoreFoundation.CFNumberCreate
 import platform.CoreFoundation.CFRelease
+import platform.CoreFoundation.CFStringRef
 import platform.CoreFoundation.CFURLRef
 import platform.CoreFoundation.kCFNumberIntType
 import platform.Foundation.CFBridgingRetain
@@ -46,6 +47,17 @@ import platform.Photos.PHPhotoLibrary
 import kotlin.coroutines.resume
 
 private const val ALBUM_TITLE = "Film Simulator"
+
+// File extensions for camera RAW formats. ImageIO can read most of these but
+// generally can't write them, and even where it can, re-encoding processed
+// sRGB pixels as RAW is meaningless — the RAW container is for unprocessed
+// sensor data. For these inputs the export is downgraded to JPEG while still
+// carrying the original EXIF/GPS/TIFF dictionary so capture metadata survives.
+private val RAW_EXTENSIONS = setOf(
+    "dng", "raw", "nef", "cr2", "cr3", "arw", "rw2", "raf", "orf", "pef", "srw", "x3f",
+)
+
+private const val JPEG_UTI = "public.jpeg"
 
 actual val systemTemporaryPath = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
 actual fun saveImageFile(fileName: String, image: ByteArray) {
@@ -131,6 +143,7 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
 
     var destinationTmpPath: String? = null
     var mergedProps: CFMutableDictionaryRef? = null
+    var ownedDestUti: CFStringRef? = null
 
     try {
         val originalSource = CGImageSourceCreateWithURL(originalCfUrl, null)
@@ -153,16 +166,33 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
             CFRelease(orientationNum)
         }
 
-        val ext = extensionForExtension(
-            originalImageFile.substringAfterLast('.', "jpg").lowercase()
-        )
+        // For RAW sources we downgrade the container to JPEG (sourceUti would
+        // be e.g. com.adobe.dng, which CGImageDestination can't write — and
+        // wouldn't be meaningful anyway since we have processed sRGB pixels).
+        // mergedProps still carries the original EXIF dictionary, which ImageIO
+        // happily writes into the JPEG APP1 segment.
+        val srcExt = originalImageFile.substringAfterLast('.', "jpg").lowercase()
+        val isRaw = srcExt in RAW_EXTENSIONS
+        val ext = if (isRaw) "jpg" else extensionForExtension(srcExt)
+        val destUti: CFStringRef = if (isRaw) {
+            // CFBridgingRetain returns +1 — track in ownedDestUti so the
+            // outer finally releases it. sourceUti is borrowed, no release.
+            // K/N implicitly bridges Kotlin String to NSString at the call site.
+            val owned = CFBridgingRetain(JPEG_UTI) as CFStringRef?
+                ?: return@withContext false
+            ownedDestUti = owned
+            owned
+        } else {
+            sourceUti
+        }
+
         val tmpPath = NSTemporaryDirectory() + "export-${NSUUID().UUIDString}.$ext"
         destinationTmpPath = tmpPath
         val tmpUrl = NSURL.fileURLWithPath(tmpPath)
         val tmpCfUrl = CFBridgingRetain(tmpUrl) as CFURLRef? ?: return@withContext false
 
         val ok = try {
-            val destination = CGImageDestinationCreateWithURL(tmpCfUrl, sourceUti, 1u, null)
+            val destination = CGImageDestinationCreateWithURL(tmpCfUrl, destUti, 1u, null)
                 ?: return@withContext false
             CGImageDestinationAddImageFromSource(destination, processedSource, 0u, mergedProps)
             CGImageDestinationFinalize(destination)
@@ -199,6 +229,7 @@ private suspend fun saveImageWithOriginalFormatAndMetadata(
         CFRelease(originalCfUrl)
         CFRelease(processedCfUrl)
         if (mergedProps != null) CFRelease(mergedProps)
+        if (ownedDestUti != null) CFRelease(ownedDestUti)
         destinationTmpPath?.let { runCatching { FileSystem.SYSTEM.delete(it.toPath()) } }
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the film simulation image processing pipeline and related infrastructure. The main changes include the addition of a high-quality, film-like grain rendering mode for image exports, support for progress reporting during image processing, and various parameter adjustments to enhance tonal and LUT controls. Additionally, new GitHub Actions workflows have been introduced for building Android and iOS apps, and a reusable Gradle setup action has been added.

**Image Processing Enhancements:**

* Added a high-quality grain rendering mode (`highQualityGrain`) that emulates real film grain using multi-octave fractal value noise, per-channel cell sizes, and density-weighted blending. This mode is much more computationally expensive and is intended for exports, while previews continue using the fast per-pixel hash approach. The `grainQuality` uniform and associated shader logic were added to support this. [[1]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6R62-R72) [[2]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6R81-R82) [[3]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6L92-R115) [[4]](diffhunk://#diff-f980966e44a3e769e5fc5b2136334a03af29329c3e7425908eb99ed435f43db0L28-R42) [[5]](diffhunk://#diff-f980966e44a3e769e5fc5b2136334a03af29329c3e7425908eb99ed435f43db0R115-R151) [[6]](diffhunk://#diff-f980966e44a3e769e5fc5b2136334a03af29329c3e7425908eb99ed435f43db0L202-R305) [[7]](diffhunk://#diff-f980966e44a3e769e5fc5b2136334a03af29329c3e7425908eb99ed435f43db0R319)
* The `process` method now accepts an `onProgress` callback, enabling the image render to be split into tiles and yield progress updates. This allows the UI to display a smooth progress bar during long-running exports. [[1]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6R62-R72) [[2]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6R81-R82) [[3]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6R144-R179)

**Adjustment Parameter Updates:**

* Extended the `lutIntensity` parameter to accept values from 0 to 200, allowing for extrapolation past the LUT result to amplify subtle film stocks. Shader and UI logic were updated accordingly. [[1]](diffhunk://#diff-f0a735fe5e30019fda607e113c75791f9aa867c0f265ee09cad67978ccfcbad9L17-R21) [[2]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6L79-R95) [[3]](diffhunk://#diff-f980966e44a3e769e5fc5b2136334a03af29329c3e7425908eb99ed435f43db0L28-R42)
* Adjusted the scaling and clamping of `contrast` and `shadows` parameters for finer control and improved tonal feel. [[1]](diffhunk://#diff-ae535a349ec483d735ee8d325a9b458f13a721aacfae300abe04d7013f848ef6L92-R115) [[2]](diffhunk://#diff-f980966e44a3e769e5fc5b2136334a03af29329c3e7425908eb99ed435f43db0L28-R42)
* Added clamping in the shader to prevent out-of-range values when extrapolating LUT intensity, ensuring numerical stability.

**Build and CI Improvements:**

* Added a new GitHub Actions workflow (`build.yml`) to automate building Android and iOS apps, including artifact upload steps.
* Created a reusable composite GitHub Action (`gradle-setup`) for setting up Java 17 and Gradle in CI jobs.

**UI Integration:**

* Updated the home screen and progress dialog to accept and display loading progress, enabling a responsive progress bar during long operations. [[1]](diffhunk://#diff-bf6669d0d51b132b199e9dfafb2b77f9ad0471d1b4ee74b29a94df077facba3fR175) [[2]](diffhunk://#diff-bf6669d0d51b132b199e9dfafb2b77f9ad0471d1b4ee74b29a94df077facba3fL253-R257)